### PR TITLE
[NF][IP] libc: add math/complex/bitops runtime, rework malloc & stdio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 tests/build/
 .gdb_history
 .vscode
+*.o

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC ?= gcc
-CFLAGS = -Wall -Werror -Ilibs -g -fPIC -pedantic -gdwarf -nostdlib -nostdinc -I. -I../../source/sys/include -I../tinycc/include
+CFLAGS = -Wall -Werror -Wno-nonnull-compare -Ilibs -g -fPIC -pedantic -gdwarf -nostdlib -nostdinc -I. -I../../source/sys/include -I../tinycc/include
 LDFLAGS_STATIC = -nostdlib -gdwarf -L../tinycc -g
 LDFLAGS = -shared -fPIC ${LDFLAGS_STATIC}
 LDFLAGS_ELF = $(LDFLAGS) -rdynamic

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CC ?= gcc
 CFLAGS = -Wall -Werror -Wno-nonnull-compare -Ilibs -g -fPIC -pedantic -gdwarf -nostdlib -nostdinc -I. -I../../source/sys/include -I../tinycc/include
+CFLAGS += $(ROOTFS_OPT_CFLAGS)
 LDFLAGS_STATIC = -nostdlib -gdwarf -L../tinycc -g
 LDFLAGS = -shared -fPIC ${LDFLAGS_STATIC}
 LDFLAGS_ELF = $(LDFLAGS) -rdynamic

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ LDFLAGS_ELF = $(LDFLAGS) -rdynamic
 EXTERNAL_LIBS =
 ifeq ($(CC), armv8m-tcc)
 CFLAGS += -DYASLIBC_ARM_SVC_TRIGGER
+# RELRO: keep .rodata pure-const (pointer-bearing const objects go to the
+# writable data segment) so it can be shared XIP across processes.
+CFLAGS += -share-rodata
 LDFLAGS_STATIC += -Wl,-Ttext=0x0
 LDFLAGS += -larmv8m-libtcc1.a
 SRCS = arm/setjmp.S arm/vfork.S arm/call_with_got.S

--- a/arm/crt1.c
+++ b/arm/crt1.c
@@ -17,6 +17,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 extern char **environ;
 

--- a/arm/crt1.c
+++ b/arm/crt1.c
@@ -61,5 +61,6 @@ void __crt1_main(int argc, char *argv[], void *r9_value) {
 
   fflush(stdout);
   fflush(stderr);
-  exit(main(argc, argv));
+  int ret = main(argc, argv);
+  exit(ret);
 }

--- a/arm/crt1.c
+++ b/arm/crt1.c
@@ -34,13 +34,14 @@ int main(int argc, char *argv[]);
 
 /* Pure-assembly _start: capture R9 (GOT base) into R2 before any
  * GOT-relative C code runs, then tail-call __crt1_main. */
-__asm__(".syntax unified\n"
-        ".thumb\n"
-        ".global _start\n"
-        ".thumb_func\n"
-        "_start:\n"
-        "  mov r2, r9\n"
-        "  b __crt1_main\n");
+__attribute__((naked, used))
+void _start(void) {
+  __asm__ volatile(
+    ".syntax unified\n"
+    "mov r2, r9\n"
+    "b __crt1_main\n"
+  );
+}
 
 void __crt1_main(int argc, char *argv[], void *r9_value) {
   environ = (char **)malloc(sizeof(char *));
@@ -50,17 +51,17 @@ void __crt1_main(int argc, char *argv[], void *r9_value) {
 
   if (__yaff_initfini) {
     unsigned int init_count = __yaff_initfini[0];
+    unsigned int fini_count = __yaff_initfini[1];
     void (**init_funcs)(void) = (void (**)(void))&__yaff_initfini[2];
 
     /* Run constructors (forward order) */
-    for (unsigned int i = 0; i < init_count; i++)
+    for (unsigned int i = 0; i < init_count; i++) {
       init_funcs[i]();
+    }
   }
 
   __yasos_fini_table = __yaff_initfini;
 
-  fflush(stdout);
-  fflush(stderr);
   int ret = main(argc, argv);
   exit(ret);
 }

--- a/arm/crt1.c
+++ b/arm/crt1.c
@@ -45,8 +45,12 @@ void _start(void) {
 }
 
 void __crt1_main(int argc, char *argv[], void *r9_value) {
-  environ = (char **)malloc(sizeof(char *));
-  environ[0] = 0;
+  /* The kernel lays out argv and envp contiguously (SysV convention):
+   *   [ argv0 .. argv(argc-1), NULL, env0 .. env(envc-1), NULL ]
+   * so the environment array starts right after argv's NULL terminator.
+   * A trailing NULL is always present (empty env => environ points at it),
+   * making this valid regardless of environment size. */
+  environ = (char **)&argv[argc + 1];
 
   __yasos_fini_got = r9_value;
 

--- a/arm/vfork.S
+++ b/arm/vfork.S
@@ -18,6 +18,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+// Enable FP instruction encodings (vpush/vpop) regardless of the -mfpu the
+// library is built with; whether the FP register file is actually saved is
+// decided at runtime below via CONTROL.FPCA.
+.fpu fpv5-sp-d16
+
 .global vfork
 .thumb_func
 vfork:

--- a/bitops.c
+++ b/bitops.c
@@ -1,0 +1,120 @@
+// Copyright (c) 2025 Mateusz Stadnik <matgla@live.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <limits.h>
+#include <strings.h>
+
+static int first_set_bit(unsigned long long value) {
+  int position = 1;
+
+  while (value != 0) {
+    if ((value & 1ULL) != 0)
+      return position;
+    value >>= 1;
+    position++;
+  }
+
+  return 0;
+}
+
+static int leading_zero_bits(unsigned long long value, int bit_count) {
+  int count = 0;
+  unsigned long long mask;
+
+  if (value == 0)
+    return bit_count;
+
+  mask = 1ULL << (bit_count - 1);
+  while ((value & mask) == 0) {
+    count++;
+    mask >>= 1;
+  }
+
+  return count;
+}
+
+static int trailing_zero_bits(unsigned long long value, int bit_count) {
+  int count = 0;
+
+  if (value == 0)
+    return bit_count;
+
+  while ((value & 1ULL) == 0) {
+    count++;
+    value >>= 1;
+  }
+
+  return count;
+}
+
+static int popcount_bits(unsigned long long value) {
+  int count = 0;
+
+  while (value != 0) {
+    count += (int)(value & 1ULL);
+    value >>= 1;
+  }
+
+  return count;
+}
+
+int ffs(int value) {
+  return first_set_bit((unsigned int)value);
+}
+
+int ffsl(long value) {
+  return first_set_bit((unsigned long)value);
+}
+
+int ffsll(long long value) {
+  return first_set_bit((unsigned long long)value);
+}
+
+int __clzsi2(unsigned int value) {
+  return leading_zero_bits(value, sizeof(value) * CHAR_BIT);
+}
+
+int __ctzsi2(unsigned int value) {
+  return trailing_zero_bits(value, sizeof(value) * CHAR_BIT);
+}
+
+int __paritysi2(unsigned int value) {
+  return popcount_bits(value) & 1;
+}
+
+int __popcountsi2(unsigned int value) {
+  return popcount_bits(value);
+}
+
+int __clzdi2(unsigned long long value) {
+  return leading_zero_bits(value, sizeof(value) * CHAR_BIT);
+}
+
+int __ctzdi2(unsigned long long value) {
+  return trailing_zero_bits(value, sizeof(value) * CHAR_BIT);
+}
+
+int __popcountdi2(unsigned long long value) {
+  return popcount_bits(value);
+}
+
+int __paritydi2(unsigned long long value) {
+  return popcount_bits(value) & 1;
+}

--- a/complex.c
+++ b/complex.c
@@ -1,0 +1,109 @@
+// Copyright (c) 2025 Mateusz Stadnik <matgla@live.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+typedef union {
+  float _Complex value;
+  struct {
+    float real;
+    float imag;
+  } parts;
+} float_complex_parts;
+
+typedef union {
+  double _Complex value;
+  struct {
+    double real;
+    double imag;
+  } parts;
+} double_complex_parts;
+
+typedef union {
+  long double _Complex value;
+  struct {
+    long double real;
+    long double imag;
+  } parts;
+} long_double_complex_parts;
+
+float _Complex conjf(float _Complex value) {
+  float_complex_parts result;
+
+  result.value = value;
+  result.parts.imag = -result.parts.imag;
+  return result.value;
+}
+
+double _Complex conj(double _Complex value) {
+  double_complex_parts result;
+
+  result.value = value;
+  result.parts.imag = -result.parts.imag;
+  return result.value;
+}
+
+long double _Complex conjl(long double _Complex value) {
+  long_double_complex_parts result;
+
+  result.value = value;
+  result.parts.imag = -result.parts.imag;
+  return result.value;
+}
+
+float crealf(float _Complex value) {
+  float_complex_parts parts;
+
+  parts.value = value;
+  return parts.parts.real;
+}
+
+double creal(double _Complex value) {
+  double_complex_parts parts;
+
+  parts.value = value;
+  return parts.parts.real;
+}
+
+long double creall(long double _Complex value) {
+  long_double_complex_parts parts;
+
+  parts.value = value;
+  return parts.parts.real;
+}
+
+float cimagf(float _Complex value) {
+  float_complex_parts parts;
+
+  parts.value = value;
+  return parts.parts.imag;
+}
+
+double cimag(double _Complex value) {
+  double_complex_parts parts;
+
+  parts.value = value;
+  return parts.parts.imag;
+}
+
+long double cimagl(long double _Complex value) {
+  long_double_complex_parts parts;
+
+  parts.value = value;
+  return parts.parts.imag;
+}

--- a/dirent.c
+++ b/dirent.c
@@ -11,7 +11,10 @@ struct __dirent_dir {
   int fd;
   int buf_pos;
   int buf_end;
-  char buf[2048];
+  /* getdents scratch. 1 KiB still batches several entries per syscall and keeps
+   * the whole DIR under MSETMAX so it stays in the malloc pool (no dedicated
+   * page) instead of a direct mmap. */
+  char buf[1024];
 };
 
 DIR *opendir(const char *path) {

--- a/endian.h
+++ b/endian.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2025 Mateusz Stadnik <matgla@live.com>
+// Please check the LICENSE file for copying conditions.
+
+#pragma once
+
+/* Byte-order macros (glibc/newlib compatible).  YasOS targets are
+ * little-endian ARM only. */
+
+#define __LITTLE_ENDIAN 1234
+#define __BIG_ENDIAN 4321
+#define __PDP_ENDIAN 3412
+
+#define __BYTE_ORDER __LITTLE_ENDIAN
+
+#define LITTLE_ENDIAN __LITTLE_ENDIAN
+#define BIG_ENDIAN __BIG_ENDIAN
+#define PDP_ENDIAN __PDP_ENDIAN
+#define BYTE_ORDER __BYTE_ORDER

--- a/errno.h
+++ b/errno.h
@@ -40,7 +40,8 @@ extern int sys_nerr;
 #define EDOM 33    /* Math argument out of domain of func */
 #define ERANGE 34  /* Math result not representable */
 #define ELOOP 35   /* Too many symbolic links encountered */
-#define ENOSYS 36  /* Function not implemented */
-#define ENOTSUP 37 /* Not supported */
+#define ENAMETOOLONG 36 /* File name too long */
+#define ENOSYS 37  /* Function not implemented */
+#define ENOTSUP 38 /* Not supported */
 
 #endif

--- a/fcntl.c
+++ b/fcntl.c
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include <fcntl.h>
 #include <stdio.h>
 
 #include "sys/syscall.h"

--- a/fcntl.h
+++ b/fcntl.h
@@ -66,9 +66,7 @@ int fcntl(int fd, int cmd, ...);
 
 int openat(int dirfd, const char *pathname, int flags, ...);
 
-typedef int32_t pid_t;
-typedef signed long off_t;
-
+/* pid_t / off_t now live in <sys/types.h> (included above). */
 struct flock {
   short l_type;   /* Type of lock: F_RDLCK, F_WRLCK, or F_UNLCK */
   short l_whence; /* How to interpret l_start: SEEK_SET, SEEK_CUR, SEEK_END */

--- a/limits.h
+++ b/limits.h
@@ -2,32 +2,32 @@
 #define _LIMITS_H
 
 #define CHAR_BIT 8
-#define SCHAR_MIN -127
+#define SCHAR_MIN (-127 - 1)
 #define SCHAR_MAX 127
 #define UCHAR_MAX 255u
 #define CHAR_MIN SCHAR_MIN
 #define CHAR_MAX SCHAR_MAX
 #define MB_LEN_MAX 4
 
-#define SHRT_MIN -32767
+#define SHRT_MIN (-32767 - 1)
 #define SHRT_MAX 32767
 #define USHRT_MAX 65535u
-#define INT_MIN -2147483647
+#define INT_MIN (-2147483647 - 1)
 #define INT_MAX 2147483647
 #define UINT_MAX 4294967295u
 
 #define PATH_MAX 128
 
-#define LLONG_MAX 9223372036854775807
+#define LLONG_MAX 9223372036854775807LL
 #define LLONG_MIN (-9223372036854775807LL - 1)
 #define ULLONG_MAX 0xffffffffffffffffULL
 
 #if defined(__x86_64__) || defined(__aarch64__)
-#define LONG_MIN -9223372036854775807l
+#define LONG_MIN (-9223372036854775807l - 1)
 #define LONG_MAX 9223372036854775807l
 #define ULONG_MAX 18446744073709551615lu
 #else
-#define LONG_MIN -2147483647l
+#define LONG_MIN (-2147483647l - 1)
 #define LONG_MAX 2147483647l
 #define ULONG_MAX 4294967295ul
 #define SIZE_MAX 0xfffffffflu

--- a/malloc.c
+++ b/malloc.c
@@ -89,6 +89,28 @@ struct mhdr {
 static struct mset *pool;
 static struct mset *pool1; /* a freed pool */
 
+/* vfork save/restore — prevents child from corrupting parent's pool state */
+static struct mset *vfork_saved_pool;
+static struct mset *vfork_saved_pool1;
+static int vfork_saved_pool_size;
+static int vfork_saved_pool_refs;
+
+void __malloc_vfork_save(void) {
+  vfork_saved_pool = pool;
+  vfork_saved_pool1 = pool1;
+  vfork_saved_pool_size = pool ? pool->size : 0;
+  vfork_saved_pool_refs = pool ? pool->refs : 0;
+}
+
+void __malloc_vfork_restore(void) {
+  pool = vfork_saved_pool;
+  pool1 = vfork_saved_pool1;
+  if (pool) {
+    pool->size = vfork_saved_pool_size;
+    pool->refs = vfork_saved_pool_refs;
+  }
+}
+
 static int mk_pool(void) {
   if ((pool == NULL || pool->refs > 0) && pool1 != NULL) {
     pool = pool1;

--- a/malloc.c
+++ b/malloc.c
@@ -8,19 +8,6 @@
 #define MSETMAX 4096
 #define MSETLEN (1 << 15)
 
-/* malloc profiling - prints stats to stderr */
-static long prof_current;      /* bytes currently mapped via mmap */
-static long prof_peak;         /* high water mark */
-static long prof_total_mapped; /* cumulative bytes mmapped */
-static int prof_malloc_calls;
-static int prof_free_calls;
-static int prof_realloc_calls;
-static int prof_mmap_calls;
-static int prof_munmap_calls;
-static int prof_inplace; /* realloc served in-place */
-static int prof_pool_allocs;
-static int prof_large_allocs;
-
 /* Tracking table for large allocations - eliminates the 4KB header page
    overhead per allocation. Each entry is 8 bytes vs 4096 bytes wasted. */
 #define MAX_LARGE_ALLOCS 256
@@ -38,46 +25,12 @@ static struct large_alloc *find_large(void *ptr) {
   return NULL;
 }
 
-static void prof_map(long sz) {
-  prof_current += sz;
-  prof_total_mapped += sz;
-  prof_mmap_calls++;
-  if (prof_current > prof_peak)
-    prof_peak = prof_current;
-}
-
-static void prof_unmap(long sz) {
-  prof_current -= sz;
-  prof_munmap_calls++;
-}
-
-void malloc_dump_profile(void) {
-  fprintf(stderr, "[malloc] current=%ldK peak=%ldK total_mapped=%ldK\n",
-          prof_current / 1024, prof_peak / 1024, prof_total_mapped / 1024);
-  fprintf(stderr,
-          "[malloc] calls: malloc=%d(pool=%d,large=%d) free=%d "
-          "realloc=%d(inplace=%d)\n",
-          prof_malloc_calls, prof_pool_allocs, prof_large_allocs,
-          prof_free_calls, prof_realloc_calls, prof_inplace);
-  fprintf(stderr, "[malloc] mmap=%d munmap=%d\n", prof_mmap_calls,
-          prof_munmap_calls);
-  /* dump active large allocations */
-  int active = 0;
-  long active_bytes = 0;
-  for (int i = 0; i < MAX_LARGE_ALLOCS; i++) {
-    if (large_table[i].addr) {
-      active++;
-      active_bytes += large_table[i].mapped_size;
-    }
-  }
-  fprintf(stderr, "[malloc] large: active=%d active_bytes=%ldK\n", active,
-          active_bytes / 1024);
-}
-
 /* placed at the beginning of regions for small allocations */
 struct mset {
-  int refs; /* number of allocations */
-  int size; /* remaining size */
+  int refs;     /* number of allocations */
+  int size;     /* bump pointer (next free offset) */
+  void *freelist; /* singly-linked list of freed blocks for reuse */
+  struct mset *next_pool; /* linked list of old pools with refs > 0 */
 };
 
 /* placed before each small allocation */
@@ -86,39 +39,103 @@ struct mhdr {
   int size; /* allocation size */
 };
 
+/* overlays mhdr in freed blocks (must be >= sizeof(mhdr)) */
+struct free_node {
+  struct free_node *next;
+  int block_size; /* total block size including mhdr, aligned */
+};
+
 static struct mset *pool;
 static struct mset *pool1; /* a freed pool */
+static struct mset *old_pools; /* linked list of full pools with refs > 0 */
 
 /* vfork save/restore — prevents child from corrupting parent's pool state */
 static struct mset *vfork_saved_pool;
 static struct mset *vfork_saved_pool1;
+static struct mset *vfork_saved_old_pools;
 static int vfork_saved_pool_size;
 static int vfork_saved_pool_refs;
+static void *vfork_saved_pool_freelist;
 
 void __malloc_vfork_save(void) {
   vfork_saved_pool = pool;
   vfork_saved_pool1 = pool1;
+  vfork_saved_old_pools = old_pools;
   vfork_saved_pool_size = pool ? pool->size : 0;
   vfork_saved_pool_refs = pool ? pool->refs : 0;
+  vfork_saved_pool_freelist = pool ? pool->freelist : 0;
 }
 
 void __malloc_vfork_restore(void) {
+  /* munmap any pools the vfork child allocated that differ from the saved
+     parent state — otherwise they become orphaned and leak. */
+  if (pool && pool != vfork_saved_pool && pool != vfork_saved_pool1)
+    munmap(pool, MSETLEN);
+  if (pool1 && pool1 != vfork_saved_pool && pool1 != vfork_saved_pool1)
+    munmap(pool1, MSETLEN);
   pool = vfork_saved_pool;
   pool1 = vfork_saved_pool1;
+  old_pools = vfork_saved_old_pools;
   if (pool) {
     pool->size = vfork_saved_pool_size;
     pool->refs = vfork_saved_pool_refs;
+    pool->freelist = vfork_saved_pool_freelist;
+  }
+}
+
+/* Insert a freed block into a pool's free list, sorted by address.
+   Coalesces with adjacent free blocks to combat fragmentation. */
+static void freelist_insert(struct mset *mset, void *ptr, int block_size) {
+  struct free_node *fn = (struct free_node *)ptr;
+  fn->block_size = block_size;
+
+  struct free_node **prev = (struct free_node **)&mset->freelist;
+  struct free_node *prev_node = NULL;
+  struct free_node *cur;
+
+  /* Find sorted position by address */
+  while ((cur = *prev) && cur < fn) {
+    prev_node = cur;
+    prev = &cur->next;
+  }
+
+  /* Insert */
+  fn->next = cur;
+  *prev = fn;
+
+  /* Coalesce with next block if adjacent */
+  if (cur && (char *)fn + fn->block_size == (char *)cur) {
+    fn->block_size += cur->block_size;
+    fn->next = cur->next;
+  }
+
+  /* Coalesce with previous block if adjacent */
+  if (prev_node && (char *)prev_node + prev_node->block_size == (char *)fn) {
+    prev_node->block_size += fn->block_size;
+    prev_node->next = fn->next;
   }
 }
 
 static int mk_pool(void) {
+  struct mset *old_pool = pool;
   if ((pool == NULL || pool->refs > 0) && pool1 != NULL) {
     pool = pool1;
     pool1 = NULL;
   }
   if (pool != NULL && pool->refs == 0) {
+    /* Chain the old full pool before recycling pool1 */
+    if (old_pool && old_pool != pool && old_pool->refs > 0) {
+      old_pool->next_pool = old_pools;
+      old_pools = old_pool;
+    }
     pool->size = sizeof(*pool);
+    pool->freelist = 0;
     return 0;
+  }
+  /* Chain old pool with live refs onto old_pools list */
+  if (old_pool && old_pool->refs > 0) {
+    old_pool->next_pool = old_pools;
+    old_pools = old_pool;
   }
   pool = mmap(NULL, MSETLEN, PROT_READ | PROT_WRITE,
               MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
@@ -126,9 +143,10 @@ static int mk_pool(void) {
     pool = NULL;
     return 1;
   }
-  prof_map(MSETLEN);
   pool->size = sizeof(*pool);
   pool->refs = 0;
+  pool->freelist = 0;
+  pool->next_pool = 0;
   return 0;
 }
 
@@ -136,20 +154,13 @@ void *malloc(size_t n) {
   void *m;
   size_t alloc_size;
   int offset;
-  prof_malloc_calls++;
   if (n >= MSETMAX) {
     long total = (n + PGMASK) & ~PGMASK; /* page-align, no header page */
     m = mmap(NULL, total, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS,
              -1, 0);
     if (m == MAP_FAILED) {
-      fprintf(stderr,
-              "[malloc] FAIL large n=%ld total=%ld cur=%ldK peak=%ldK\n",
-              (long)n, total, prof_current / 1024, prof_peak / 1024);
-      malloc_dump_profile();
       return NULL;
     }
-    prof_map(total);
-    prof_large_allocs++;
     for (int i = 0; i < MAX_LARGE_ALLOCS; i++) {
       if (!large_table[i].addr) {
         large_table[i].addr = m;
@@ -158,15 +169,42 @@ void *malloc(size_t n) {
         return m;
       }
     }
-    prof_unmap(total);
     munmap(m, total);
     return NULL;
   }
-  prof_pool_allocs++;
   alloc_size = (n + sizeof(struct mhdr) + 7) & ~7;
   if (!pool)
     if (mk_pool())
       return NULL;
+  /* Search current pool's free list for a reusable block */
+  {
+    struct free_node **prev = (struct free_node **)&pool->freelist, *fn;
+    while ((fn = *prev)) {
+      if (fn->block_size >= (int)alloc_size) {
+        int remainder = fn->block_size - (int)alloc_size;
+        *prev = fn->next;
+        /* Split if remainder can hold a minimum-sized allocation (16 bytes).
+           sizeof(struct free_node) is only 8, but min alloc_size is 16,
+           so 8-byte splits would create permanently unusable fragments. */
+        if (remainder >= 2 * (int)sizeof(struct mhdr)) {
+          struct free_node *split = (struct free_node *)((char *)fn + alloc_size);
+          split->block_size = remainder;
+          split->next = *prev;
+          *prev = split;
+          fn->block_size = alloc_size;
+        }
+        m = (void *)fn;
+        ((struct mhdr *)m)->moff = (char *)m - (char *)pool;
+        ((struct mhdr *)m)->size = n;
+        pool->refs++;
+        return m + sizeof(struct mhdr);
+      }
+      prev = &fn->next;
+    }
+  }
+  /* NOTE: We deliberately do NOT search old_pools' freelists here.
+     Allocating from old pools adds refs, preventing them from ever reaching
+     zero and being reclaimed.  Let old pools drain naturally via free(). */
   offset = pool->size;
   if (!((unsigned long)((char *)pool + offset + sizeof(struct mhdr)) & PGMASK))
     offset += sizeof(long);
@@ -186,32 +224,40 @@ void *malloc(size_t n) {
   if (!((unsigned long)((char *)pool + pool->size + sizeof(struct mhdr)) &
         PGMASK))
     pool->size += sizeof(long);
-  {
-    void *ret = m + sizeof(struct mhdr);
-    return ret;
-  }
+  return m + sizeof(struct mhdr);
 }
 
 void free(void *v) {
   if (!v)
     return;
-  prof_free_calls++;
   if ((unsigned long)v & PGMASK) {
     struct mhdr *mhdr = v - sizeof(struct mhdr);
     struct mset *mset = (void *)mhdr - mhdr->moff;
     mset->refs--;
     if (mset->refs == 0 && mset != pool) {
+      /* Remove from old_pools list if present */
+      struct mset **pp = &old_pools;
+      while (*pp) {
+        if (*pp == mset) { *pp = mset->next_pool; break; }
+        pp = &(*pp)->next_pool;
+      }
       if (pool1 != NULL) {
-        prof_unmap(MSETLEN);
         munmap(mset, MSETLEN);
       } else {
         pool1 = mset;
       }
+    } else if (mset != pool && mset->refs > 0) {
+      /* Block freed into non-current pool - these are unreachable by malloc */
+      int block_size = ((mhdr->size + sizeof(struct mhdr) + 7) & ~7);
+      freelist_insert(mset, mhdr, block_size);
+    } else {
+      /* Add freed block to current pool's free list for reuse */
+      int block_size = ((mhdr->size + sizeof(struct mhdr) + 7) & ~7);
+      freelist_insert(mset, mhdr, block_size);
     }
   } else {
     struct large_alloc *e = find_large(v);
     if (e) {
-      prof_unmap(e->mapped_size);
       munmap(e->addr, e->mapped_size);
       e->addr = NULL;
     }
@@ -236,7 +282,6 @@ void *realloc(void *v, size_t sz) {
   void *r;
   long old_size;
 
-  prof_realloc_calls++;
   if (!v)
     return malloc(sz);
   if (!sz) {
@@ -264,7 +309,6 @@ void *realloc(void *v, size_t sz) {
     if (e) {
       /* Check if new size fits in already-mapped pages */
       if ((long)sz <= e->mapped_size) {
-        prof_inplace++;
         e->user_size = sz;
         return v;
       }
@@ -272,8 +316,6 @@ void *realloc(void *v, size_t sz) {
       long new_mapped = (sz + PGMASK) & ~PGMASK;
       r = mremap(v, e->mapped_size, new_mapped, 0);
       if (r != NULL && r != (void *)-1) {
-        prof_inplace++;
-        prof_map(new_mapped - e->mapped_size);
         e->addr = r;
         e->mapped_size = new_mapped;
         e->user_size = sz;
@@ -284,8 +326,6 @@ void *realloc(void *v, size_t sz) {
 
   r = malloc(sz);
   if (!r) {
-    fprintf(stderr, "[malloc] realloc FAIL old=%ld new=%ld cur=%ldK\n",
-            old_size, (long)sz, prof_current / 1024);
     return NULL;
   }
   memcpy(r, v, old_size < (long)sz ? old_size : sz);

--- a/malloc.c
+++ b/malloc.c
@@ -3,6 +3,22 @@
 #include <string.h>
 #include <sys/mman.h>
 
+#define MALLOC_DEBUG 0
+
+
+
+#if MALLOC_DEBUG
+/* GDB: break malloc_debug_trap */
+static volatile int malloc_debug_trap_hit;
+void __attribute__((noinline)) malloc_debug_trap(void *block, int size, int alloc_size) {
+  malloc_debug_trap_hit++;
+#if defined(__arm__) || defined(__thumb__)
+  asm volatile("bkpt #1");
+#endif
+  (void)block; (void)size; (void)alloc_size;
+}
+#endif
+
 #define PGSIZE 4096
 #define PGMASK (PGSIZE - 1)
 #define MSETMAX 4096
@@ -89,6 +105,14 @@ static void freelist_insert(struct mset *mset, void *ptr, int block_size) {
   struct free_node *fn = (struct free_node *)ptr;
   fn->block_size = block_size;
 
+#if MALLOC_DEBUG
+  /* Validate block is within the pool */
+  if ((char *)ptr < (char *)mset || (char *)ptr + block_size > (char *)mset + MSETLEN) {
+    fprintf(stderr, "[malloc] BAD FREE: ptr=%p blk=%d pool=%p..%p\n",
+            ptr, block_size, mset, (char *)mset + MSETLEN);
+  }
+#endif
+
   struct free_node **prev = (struct free_node **)&mset->freelist;
   struct free_node *prev_node = NULL;
   struct free_node *cur;
@@ -107,12 +131,21 @@ static void freelist_insert(struct mset *mset, void *ptr, int block_size) {
   if (cur && (char *)fn + fn->block_size == (char *)cur) {
     fn->block_size += cur->block_size;
     fn->next = cur->next;
+#if MALLOC_DEBUG
+    /* Re-poison merged area so stale free_node headers don't cause false positives */
+    memset((char *)fn + sizeof(struct free_node), 0xDE,
+           fn->block_size - sizeof(struct free_node));
+#endif
   }
 
   /* Coalesce with previous block if adjacent */
   if (prev_node && (char *)prev_node + prev_node->block_size == (char *)fn) {
     prev_node->block_size += fn->block_size;
     prev_node->next = fn->next;
+#if MALLOC_DEBUG
+    memset((char *)prev_node + sizeof(struct free_node), 0xDE,
+           prev_node->block_size - sizeof(struct free_node));
+#endif
   }
 }
 
@@ -181,6 +214,13 @@ void *malloc(size_t n) {
     struct free_node **prev = (struct free_node **)&pool->freelist, *fn;
     while ((fn = *prev)) {
       if (fn->block_size >= (int)alloc_size) {
+        /* Skip blocks where user pointer would be page-aligned —
+           page-aligned pointers are mistaken for large allocations
+           by msize()/free()/realloc(). */
+        if (!((unsigned long)((char *)fn + sizeof(struct mhdr)) & PGMASK)) {
+          prev = &fn->next;
+          continue;
+        }
         int remainder = fn->block_size - (int)alloc_size;
         *prev = fn->next;
         /* Split if remainder can hold a minimum-sized allocation (16 bytes).
@@ -192,12 +232,40 @@ void *malloc(size_t n) {
           split->next = *prev;
           *prev = split;
           fn->block_size = alloc_size;
+#if MALLOC_DEBUG
+          /* Poison the split remainder's data area */
+          memset((char *)split + sizeof(struct free_node), 0xDE,
+                 remainder - sizeof(struct free_node));
+#endif
         }
         m = (void *)fn;
+#if MALLOC_DEBUG
+        /* Check poison pattern to detect use-after-free */
+        {
+          unsigned char *data = (unsigned char *)fn + sizeof(struct mhdr);
+          int data_len = fn->block_size - sizeof(struct mhdr);
+          int corrupted = 0;
+          for (int j = 0; j < data_len && j < 64; j++) {
+            if (data[j] != 0xDE) { corrupted = 1; break; }
+          }
+          if (corrupted) {
+            fprintf(stderr, "[malloc] POISON VIOLATED: reuse %p blk=%d for n=%d\n",
+                    fn, fn->block_size, (int)n);
+            fprintf(stderr, "[malloc] data: ");
+            for (int j = 0; j < 32 && j < data_len; j++)
+              fprintf(stderr, "%02x ", data[j]);
+            fprintf(stderr, "\n");
+            malloc_debug_trap(fn, fn->block_size, (int)n);
+          }
+        }
+#endif
         ((struct mhdr *)m)->moff = (char *)m - (char *)pool;
         ((struct mhdr *)m)->size = n;
         pool->refs++;
-        return m + sizeof(struct mhdr);
+        /* Zero the returned block so callers see the same clean state
+           as from fresh bump allocation (pages come pre-zeroed). */
+        memset((char *)m + sizeof(struct mhdr), 0, n);
+        return (char *)m + sizeof(struct mhdr);
       }
       prev = &fn->next;
     }
@@ -249,10 +317,16 @@ void free(void *v) {
     } else if (mset != pool && mset->refs > 0) {
       /* Block freed into non-current pool - these are unreachable by malloc */
       int block_size = ((mhdr->size + sizeof(struct mhdr) + 7) & ~7);
+#if MALLOC_DEBUG
+      memset((char *)mhdr + sizeof(struct mhdr), 0xDE, block_size - sizeof(struct mhdr));
+#endif
       freelist_insert(mset, mhdr, block_size);
     } else {
       /* Add freed block to current pool's free list for reuse */
       int block_size = ((mhdr->size + sizeof(struct mhdr) + 7) & ~7);
+#if MALLOC_DEBUG
+      memset((char *)mhdr + sizeof(struct mhdr), 0xDE, block_size - sizeof(struct mhdr));
+#endif
       freelist_insert(mset, mhdr, block_size);
     }
   } else {
@@ -328,7 +402,10 @@ void *realloc(void *v, size_t sz) {
   if (!r) {
     return NULL;
   }
-  memcpy(r, v, old_size < (long)sz ? old_size : sz);
+  {
+    int copy_len = old_size < (long)sz ? old_size : sz;
+    memcpy(r, v, copy_len);
+  }
   free(v);
   return r;
 }

--- a/malloc.c
+++ b/malloc.c
@@ -301,6 +301,15 @@ void free(void *v) {
   if ((unsigned long)v & PGMASK) {
     struct mhdr *mhdr = v - sizeof(struct mhdr);
     struct mset *mset = (void *)mhdr - mhdr->moff;
+#if MALLOC_DEBUG
+    if ((unsigned long)v < 0x10000000UL || ((unsigned long)mset & PGMASK) ||
+        mhdr->moff < (int)sizeof(struct mset) || mhdr->moff >= MSETLEN) {
+      fprintf(stderr, "[malloc] WILD FREE v=%p moff=%d size=%d mset=%p ra=%p\n",
+              v, mhdr->moff, mhdr->size, (void *)mset,
+              __builtin_return_address(0));
+      return;
+    }
+#endif
     mset->refs--;
     if (mset->refs == 0 && mset != pool) {
       /* Remove from old_pools list if present */

--- a/malloc.c
+++ b/malloc.c
@@ -21,25 +21,38 @@ void __attribute__((noinline)) malloc_debug_trap(void *block, int size, int allo
 
 #define PGSIZE 4096
 #define PGMASK (PGSIZE - 1)
-#define MSETMAX 4096
-#define MSETLEN (1 << 15)
+/* Largest object served from the bump pool; >= this goes to a direct mmap.
+ * Must stay below MSETLEN minus pool overhead (sizeof(struct mset) + per-alloc
+ * header + page-skip slack, ~48 B): malloc does NOT recheck fit after mk_pool()
+ * (see ~line 286), so a pooled object bigger than the pool would overflow the
+ * mmap. With a 4 KiB pool that caps the threshold at ~4048; 2048 leaves margin
+ * and keeps medium objects (which are rare) on the direct-mmap path. */
+#define MSETMAX 2048
+/* Bump-pool chunk size. The kernel process pool is page-granular (4 KiB), so
+ * the first malloc maps this many pages up front. 32 KiB (the inherited 2010
+ * "neat" default) wasted ~24 KiB on light applets whose live small-object set
+ * is only 2-6 KiB. 4 KiB = one page: the minimum that still holds the largest
+ * pooled object (MSETMAX-1 + overhead). Allocations >= MSETMAX bypass the pool
+ * via direct mmap, so this never bounds large objects (e.g. tcc's). */
+#define MSETLEN (1 << 12)
 
-/* Tracking table for large allocations - eliminates the 4KB header page
-   overhead per allocation. Each entry is 8 bytes vs 4096 bytes wasted. */
-#define MAX_LARGE_ALLOCS 256
-struct large_alloc {
-  void *addr;       /* mmap base address (NULL = free slot) */
-  long mapped_size; /* total mapped bytes (page-aligned) */
-  long user_size;   /* requested user-visible allocation size */
-};
-static struct large_alloc large_table[MAX_LARGE_ALLOCS];
+/* Large allocations (>= MSETMAX) are mmap'd with a small self-describing header
+   in the mapping itself, so they are UNBOUNDED — no fixed-size tracking table
+   (which capped concurrent large allocs and returned NULL / "memory full" once
+   full) and zero per-process .bss. A central table was historically used to
+   dodge a 4 KiB header page per alloc, but the kernel page grain is now 256 B,
+   so an in-mapping header rounds the mapping up by at most one grain.
 
-static struct large_alloc *find_large(void *ptr) {
-  for (int i = 0; i < MAX_LARGE_ALLOCS; i++)
-    if (large_table[i].addr == ptr)
-      return &large_table[i];
-  return NULL;
-}
+   Header (16 B; the user pointer is 16 B past the mmap base):
+     +0  long mapped     total mmap'd bytes (for munmap / mremap)
+     +8  int  moff = -1   LARGE_MOFF sentinel. A pool block's moff is its offset
+                          into the pool, always in [0, MSETLEN), so -1 can't
+                          collide; free()/realloc() read it (at user-8, the
+                          mhdr.moff slot) to tell large from small.
+     +12 int  size        user-visible size (at user-4, the mhdr.size slot, so
+                          msize() is uniform for both small and large). */
+#define LARGE_MOFF (-1)
+#define LARGE_HDR 16
 
 /* placed at the beginning of regions for small allocations */
 struct mset {
@@ -188,22 +201,17 @@ void *malloc(size_t n) {
   size_t alloc_size;
   int offset;
   if (n >= MSETMAX) {
-    long total = (n + PGMASK) & ~PGMASK; /* page-align, no header page */
-    m = mmap(NULL, total, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS,
-             -1, 0);
-    if (m == MAP_FAILED) {
+    /* Self-tracking large alloc: header in the mapping, no table, unbounded. */
+    long total = (n + LARGE_HDR + PGMASK) & ~PGMASK;
+    char *lm = mmap(NULL, total, PROT_READ | PROT_WRITE,
+                    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (lm == MAP_FAILED) {
       return NULL;
     }
-    for (int i = 0; i < MAX_LARGE_ALLOCS; i++) {
-      if (!large_table[i].addr) {
-        large_table[i].addr = m;
-        large_table[i].mapped_size = total;
-        large_table[i].user_size = n;
-        return m;
-      }
-    }
-    munmap(m, total);
-    return NULL;
+    *(long *)lm = total;
+    ((struct mhdr *)(lm + 8))->moff = LARGE_MOFF;
+    ((struct mhdr *)(lm + 8))->size = (int)n;
+    return lm + LARGE_HDR;
   }
   alloc_size = (n + sizeof(struct mhdr) + 7) & ~7;
   if (!pool)
@@ -298,8 +306,15 @@ void *malloc(size_t n) {
 void free(void *v) {
   if (!v)
     return;
-  if ((unsigned long)v & PGMASK) {
-    struct mhdr *mhdr = v - sizeof(struct mhdr);
+  struct mhdr *mhdr = (struct mhdr *)((char *)v - sizeof(struct mhdr));
+  /* Large allocs carry the LARGE_MOFF sentinel in the mhdr.moff slot (a pool
+     block's moff is its in-pool offset, always < MSETLEN). */
+  if (mhdr->moff == LARGE_MOFF) {
+    char *base = (char *)v - LARGE_HDR;
+    munmap(base, *(long *)base);
+    return;
+  }
+  {
     struct mset *mset = (void *)mhdr - mhdr->moff;
 #if MALLOC_DEBUG
     if ((unsigned long)v < 0x10000000UL || ((unsigned long)mset & PGMASK) ||
@@ -338,12 +353,6 @@ void free(void *v) {
 #endif
       freelist_insert(mset, mhdr, block_size);
     }
-  } else {
-    struct large_alloc *e = find_large(v);
-    if (e) {
-      munmap(e->addr, e->mapped_size);
-      e->addr = NULL;
-    }
   }
 }
 
@@ -355,10 +364,8 @@ void *calloc(size_t n, size_t sz) {
 }
 
 static long msize(void *v) {
-  if ((unsigned long)v & PGMASK)
-    return ((struct mhdr *)(v - sizeof(struct mhdr)))->size;
-  struct large_alloc *e = find_large(v);
-  return e ? e->user_size : 0;
+  /* Both small and large store the user size in the mhdr.size slot (user-4). */
+  return ((struct mhdr *)((char *)v - sizeof(struct mhdr)))->size;
 }
 
 void *realloc(void *v, size_t sz) {
@@ -374,35 +381,32 @@ void *realloc(void *v, size_t sz) {
 
   old_size = msize(v);
 
-  /* If shrinking or same size, return as-is */
+  /* If shrinking or same size, return as-is (user size is in mhdr.size for
+     both small and large). */
   if ((long)sz <= old_size) {
-    if ((unsigned long)v & PGMASK) {
-      ((struct mhdr *)(v - sizeof(struct mhdr)))->size = sz;
-    } else {
-      struct large_alloc *e = find_large(v);
-      if (e)
-        e->user_size = sz;
-    }
+    ((struct mhdr *)((char *)v - sizeof(struct mhdr)))->size = sz;
     return v;
   }
 
   /* For large allocations, try to grow in-place */
-  if (!((unsigned long)v & PGMASK)) {
-    struct large_alloc *e = find_large(v);
-    if (e) {
-      /* Check if new size fits in already-mapped pages */
-      if ((long)sz <= e->mapped_size) {
-        e->user_size = sz;
+  {
+    struct mhdr *mhdr = (struct mhdr *)((char *)v - sizeof(struct mhdr));
+    if (mhdr->moff == LARGE_MOFF) {
+      char *base = (char *)v - LARGE_HDR;
+      long mapped = *(long *)base;
+      /* New size still fits in the existing mapping (minus the header)? */
+      if ((long)sz + LARGE_HDR <= mapped) {
+        mhdr->size = sz;
         return v;
       }
-      /* Try kernel mremap to extend the mapping in-place */
-      long new_mapped = (sz + PGMASK) & ~PGMASK;
-      r = mremap(v, e->mapped_size, new_mapped, 0);
+      /* Try kernel mremap to extend the mapping in-place. */
+      long new_mapped = (sz + LARGE_HDR + PGMASK) & ~PGMASK;
+      r = mremap(base, mapped, new_mapped, 0);
       if (r != NULL && r != (void *)-1) {
-        e->addr = r;
-        e->mapped_size = new_mapped;
-        e->user_size = sz;
-        return r;
+        *(long *)r = new_mapped;
+        ((struct mhdr *)((char *)r + 8))->moff = LARGE_MOFF;
+        ((struct mhdr *)((char *)r + 8))->size = sz;
+        return (char *)r + LARGE_HDR;
       }
     }
   }

--- a/math_runtime.c
+++ b/math_runtime.c
@@ -1,0 +1,127 @@
+// Copyright (c) 2025 Mateusz Stadnik <matgla@live.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <limits.h>
+
+#ifndef FP_ILOGB0
+#define FP_ILOGB0 (-INT_MAX)
+#endif
+
+#ifndef FP_ILOGBNAN
+#define FP_ILOGBNAN INT_MAX
+#endif
+
+typedef union {
+  double value;
+  unsigned long long bits;
+} double_bits;
+
+typedef union {
+  double _Complex value;
+  struct {
+    double real;
+    double imag;
+  } parts;
+} double_complex_parts;
+
+static long double fabs_local(long double value) {
+  return value < 0.0L ? -value : value;
+}
+
+static int isnan_local(long double value) {
+  return value != value;
+}
+
+static int signbit_local(long double value) {
+  double_bits repr;
+
+  repr.value = (double)value;
+  return (int)(repr.bits >> 63);
+}
+
+long double fmaxl(long double left, long double right) {
+  if (isnan_local(left))
+    return right;
+  if (isnan_local(right))
+    return left;
+  if (left > right)
+    return left;
+  if (right > left)
+    return right;
+  if (left == 0.0L && right == 0.0L)
+    return signbit_local(left) ? right : left;
+  return left;
+}
+
+int ilogbl(long double value) {
+  double_bits repr;
+  unsigned long long fraction;
+  int exponent;
+
+  repr.value = (double)value;
+  exponent = (int)((repr.bits >> 52) & 0x7ffu);
+  fraction = repr.bits & 0x000fffffffffffffull;
+
+  if (exponent == 0) {
+    int shift = 0;
+
+    if (fraction == 0)
+      return FP_ILOGB0;
+    while ((fraction & (1ULL << 51)) == 0) {
+      fraction <<= 1;
+      shift++;
+    }
+    return -1022 - shift;
+  }
+
+  if (exponent == 0x7ff)
+    return fraction == 0 ? INT_MAX : FP_ILOGBNAN;
+
+  return exponent - 1023;
+}
+
+int ilogb(double value) {
+  return ilogbl((long double)value);
+}
+
+int ilogbf(float value) {
+  return ilogbl((long double)value);
+}
+
+double _Complex __divdc3(double a_real, double a_imag, double b_real,
+                        double b_imag) {
+  double ratio;
+  double denom;
+  double_complex_parts result;
+
+  if (fabs_local(b_real) < fabs_local(b_imag)) {
+    ratio = b_real / b_imag;
+    denom = b_real * ratio + b_imag;
+    result.parts.real = (a_real * ratio + a_imag) / denom;
+    result.parts.imag = (a_imag * ratio - a_real) / denom;
+  } else {
+    ratio = b_imag / b_real;
+    denom = b_imag * ratio + b_real;
+    result.parts.real = (a_imag * ratio + a_real) / denom;
+    result.parts.imag = (a_imag - a_real * ratio) / denom;
+  }
+
+  return result.value;
+}

--- a/math_runtime.c
+++ b/math_runtime.c
@@ -105,11 +105,66 @@ int ilogbf(float value) {
   return ilogbl((long double)value);
 }
 
+typedef union {
+  float _Complex value;
+  struct {
+    float real;
+    float imag;
+  } parts;
+} float_complex_parts;
+
+static float fabsf_local(float value) {
+  return value < 0.0f ? -value : value;
+}
+
+float _Complex __divsc3(float a_real, float a_imag, float b_real,
+                        float b_imag) {
+  float ratio;
+  float denom;
+  float_complex_parts result;
+
+  if (b_imag == 0.0f) {
+    result.parts.real = a_real / b_real;
+    result.parts.imag = a_imag / b_real;
+    return result.value;
+  }
+  if (b_real == 0.0f) {
+    result.parts.real = a_imag / b_imag;
+    result.parts.imag = -(a_real / b_imag);
+    return result.value;
+  }
+
+  if (fabsf_local(b_real) < fabsf_local(b_imag)) {
+    ratio = b_real / b_imag;
+    denom = b_real * ratio + b_imag;
+    result.parts.real = (a_real * ratio + a_imag) / denom;
+    result.parts.imag = (a_imag * ratio - a_real) / denom;
+  } else {
+    ratio = b_imag / b_real;
+    denom = b_imag * ratio + b_real;
+    result.parts.real = (a_imag * ratio + a_real) / denom;
+    result.parts.imag = (a_imag - a_real * ratio) / denom;
+  }
+
+  return result.value;
+}
+
 double _Complex __divdc3(double a_real, double a_imag, double b_real,
                         double b_imag) {
   double ratio;
   double denom;
   double_complex_parts result;
+
+  if (b_imag == 0.0) {
+    result.parts.real = a_real / b_real;
+    result.parts.imag = a_imag / b_real;
+    return result.value;
+  }
+  if (b_real == 0.0) {
+    result.parts.real = a_imag / b_imag;
+    result.parts.imag = -(a_real / b_imag);
+    return result.value;
+  }
 
   if (fabs_local(b_real) < fabs_local(b_imag)) {
     ratio = b_real / b_imag;

--- a/scanf.c
+++ b/scanf.c
@@ -340,11 +340,16 @@ char *fgets(char *s, int sz, FILE *fp) {
 
 long fread(void *v, long sz, long n, FILE *fp) {
   char *s = v;
-  int i = n * sz;
-  while (i-- > 0)
-    if ((*s++ = ic(fp)) == EOF)
-      return n * sz - i - 1;
-  return n * sz;
+  long total = n * sz;
+  long rd = 0;
+  while (rd < total) {
+    int c = ic(fp);
+    if (c == EOF)
+      return rd / sz;
+    *s++ = c;
+    rd++;
+  }
+  return n;
 }
 
 int feof(FILE *fp) {

--- a/stdio.c
+++ b/stdio.c
@@ -18,6 +18,71 @@ FILE *stdin = &_stdin;
 FILE *stdout = &_stdout;
 FILE *stderr = &_stderr;
 
+static int stdio_parse_mode(const char *mode) {
+  int flags;
+
+  if (mode == NULL || *mode == '\0') {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (strchr(mode, '+'))
+    flags = O_RDWR;
+  else if (*mode == 'r')
+    flags = O_RDONLY;
+  else if (*mode == 'w' || *mode == 'a')
+    flags = O_WRONLY;
+  else {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (*mode != 'r')
+    flags |= O_CREAT;
+  if (*mode == 'w')
+    flags |= O_TRUNC;
+  if (*mode == 'a')
+    flags |= O_APPEND;
+
+  return flags;
+}
+
+static void stdio_reset_stream(FILE *fp) {
+  fp->back = EOF;
+  fp->ilen = 0;
+  fp->olen = 0;
+  fp->icur = 0;
+  fp->ostat = 0;
+  fp->istat = 0;
+}
+
+static int stdio_ensure_buffers(FILE *fp) {
+  if (fp->ibuf == NULL) {
+    fp->ibuf = malloc(BUFSIZ);
+    if (fp->ibuf == NULL)
+      return -1;
+    fp->isize = BUFSIZ;
+    fp->iown = 1;
+  }
+
+  if (fp->obuf == NULL) {
+    fp->obuf = malloc(BUFSIZ);
+    if (fp->obuf == NULL) {
+      if (fp->iown && fp->ibuf != NULL) {
+        free(fp->ibuf);
+        fp->ibuf = NULL;
+        fp->iown = 0;
+        fp->isize = 0;
+      }
+      return -1;
+    }
+    fp->osize = BUFSIZ;
+    fp->oown = 1;
+  }
+
+  return 0;
+}
+
 FILE *tmpfile(void) {
   printf("TODO: implement tmpfile()\n");
   return NULL;
@@ -25,65 +90,91 @@ FILE *tmpfile(void) {
 
 FILE *fopen(const char *path, const char *mode) {
   FILE *fp;
-  int flags;
+  int flags = stdio_parse_mode(mode);
 
-  if (strchr(mode, '+'))
-    flags = O_RDWR;
-  else
-    flags = *mode == 'r' ? O_RDONLY : O_WRONLY;
-  if (*mode != 'r')
-    flags |= O_CREAT;
-  if (*mode == 'w')
-    flags |= O_TRUNC;
-  if (*mode == 'a')
-    flags |= O_APPEND;
+  if (flags < 0)
+    return NULL;
 
   fp = malloc(sizeof(*fp));
+  if (fp == NULL)
+    return NULL;
   memset(fp, 0, sizeof(*fp));
   fp->fd = open(path, flags, 0600);
   if (fp->fd < 0) {
     free(fp);
     return NULL;
   }
-  fp->back = EOF;
-  fp->ibuf = malloc(BUFSIZ);
-  fp->obuf = malloc(BUFSIZ);
-  fp->isize = BUFSIZ;
-  fp->osize = BUFSIZ;
-  fp->iown = 1;
-  fp->oown = 1;
+  if (stdio_ensure_buffers(fp) < 0) {
+    close(fp->fd);
+    free(fp);
+    return NULL;
+  }
+  stdio_reset_stream(fp);
   return fp;
 }
 
 FILE *fdopen(int fd, const char *mode) {
   FILE *fp;
-  int flags;
+  int flags = stdio_parse_mode(mode);
 
-  if (strchr(mode, '+'))
-    flags = O_RDWR;
-  else
-    flags = *mode == 'r' ? O_RDONLY : O_WRONLY;
-  if (*mode != 'r')
-    flags |= O_CREAT;
-  if (*mode == 'w')
-    flags |= O_TRUNC;
-  if (*mode == 'a')
-    flags |= O_APPEND;
+  if (flags < 0)
+    return NULL;
 
   fp = malloc(sizeof(*fp));
+  if (fp == NULL)
+    return NULL;
   memset(fp, 0, sizeof(*fp));
   if (fcntl(fd, F_GETFL) < 0) {
     free(fp);
     return NULL;
   }
   fp->fd = fd;
-  fp->back = EOF;
-  fp->ibuf = malloc(BUFSIZ);
-  fp->obuf = malloc(BUFSIZ);
-  fp->isize = BUFSIZ;
-  fp->osize = BUFSIZ;
-  fp->iown = 1;
-  fp->oown = 1;
+  if (stdio_ensure_buffers(fp) < 0) {
+    free(fp);
+    return NULL;
+  }
+  stdio_reset_stream(fp);
+  return fp;
+}
+
+FILE *freopen(const char *path, const char *mode, FILE *fp) {
+  int flags;
+  int fd;
+
+  if (fp == NULL || path == NULL) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  flags = stdio_parse_mode(mode);
+  if (flags < 0)
+    return NULL;
+
+  if (fflush(fp) == EOF)
+    return NULL;
+
+  if (fp->fd >= 0 && close(fp->fd) < 0) {
+    fp->fd = -1;
+    stdio_reset_stream(fp);
+    return NULL;
+  }
+
+  fd = open(path, flags, 0600);
+  if (fd < 0) {
+    fp->fd = -1;
+    stdio_reset_stream(fp);
+    return NULL;
+  }
+
+  if (stdio_ensure_buffers(fp) < 0) {
+    close(fd);
+    fp->fd = -1;
+    stdio_reset_stream(fp);
+    return NULL;
+  }
+
+  fp->fd = fd;
+  stdio_reset_stream(fp);
   return fp;
 }
 
@@ -836,20 +927,14 @@ int rename(const char *oldpath, const char *newpath) {
 
 FILE *fmemopen(void *buf, size_t size, const char *mode) {
   FILE *fp;
-  int flags;
+  int flags = stdio_parse_mode(mode);
 
-  if (strchr(mode, '+'))
-    flags = O_RDWR;
-  else
-    flags = *mode == 'r' ? O_RDONLY : O_WRONLY;
-  if (*mode != 'r')
-    flags |= O_CREAT;
-  if (*mode == 'w')
-    flags |= O_TRUNC;
-  if (*mode == 'a')
-    flags |= O_APPEND;
+  if (flags < 0)
+    return NULL;
 
   fp = malloc(sizeof(*fp));
+  if (fp == NULL)
+    return NULL;
   memset(fp, 0, sizeof(*fp));
   fp->fd = -1;
   if (buf == NULL) {

--- a/stdio.c
+++ b/stdio.c
@@ -766,16 +766,24 @@ int snprintf(char *dst, size_t sz, const char *fmt, ...) {
 }
 
 int fputs(const char *s, FILE *fp) {
-  while (*s)
-    fputc((unsigned char)*s++, fp);
-  return 0;
+  if (!fp)
+    return EOF;
+  int n = 0;
+  while (*s) {
+    if (fputc((unsigned char)*s++, fp) == EOF)
+      return EOF;
+    n++;
+  }
+  return n;
 }
 
 int puts(const char *s) {
   int ret = fputs(s, stdout);
-  if (ret >= 0)
-    fputc('\n', stdout);
-  return ret;
+  if (ret == EOF)
+    return EOF;
+  if (fputc('\n', stdout) == EOF)
+    return EOF;
+  return ret + 1;
 }
 
 long fwrite(void *v, long sz, long n, FILE *fp) {

--- a/stdio.c
+++ b/stdio.c
@@ -10,7 +10,10 @@
 
 #include <fcntl.h>
 
-static char _ibuf[BUFSIZ], _obuf[BUFSIZ], _ebuf[BUFSIZ];
+static char _ibuf[BUFSIZ], _obuf[BUFSIZ];
+/* stderr's line buffer can be smaller — error lines are short, and it stays
+ * block-buffered (see below), just with a lower line-length ceiling. */
+static char _ebuf[128];
 static FILE _stdin = {0, EOF, _ibuf, NULL, BUFSIZ, 0};
 static FILE _stdout = {1, EOF, NULL, _obuf, 0, BUFSIZ};
 /* stderr is LINE-buffered (osize = BUFSIZ), not unbuffered (osize = 1).
@@ -20,7 +23,7 @@ static FILE _stdout = {1, EOF, NULL, _obuf, 0, BUFSIZ};
  * its bytes on this target (rapid single-byte writes outrun the console/FS
  * write path), which was scrambling every error message to every-other-char
  * (e.g. tcc's compile errors became unreadable). Block writes are reliable. */
-static FILE _stderr = {2, EOF, NULL, _ebuf, 0, BUFSIZ};
+static FILE _stderr = {2, EOF, NULL, _ebuf, 0, 128};
 FILE *stdin = &_stdin;
 FILE *stdout = &_stdout;
 FILE *stderr = &_stderr;
@@ -238,6 +241,11 @@ int fflush(FILE *fp) {
 
 int fputc(int c, FILE *fp) {
   if (fp->osize == 0) {
+    // String sinks (fd < 0) with no room — e.g. the vsnprintf(NULL, 0, ...)
+    // length-measuring idiom — must only count (via vfprintf's return), never
+    // touch a real fd.
+    if (fp->fd < 0)
+      return c;
     if (write(fp->fd, (char *)&c, 1) != 1)
       return EOF;
     return c;
@@ -258,6 +266,11 @@ int putchar(int c) {
 
 static int ostr(FILE *fp, char *s, int wid, int left, int max_len,
                 char fill_character) {
+  // Match glibc behaviour for printf("%s", NULL) instead of dereferencing a
+  // null pointer (which faults once the MPU is active rather than silently
+  // reading whatever 0x0 aliases on the target).
+  if (s == NULL)
+    s = "(null)";
   int str_len = strlen(s);
   str_len = str_len < max_len ? str_len : max_len;
   int fill = wid - str_len;
@@ -844,9 +857,13 @@ int vsnprintf(char *dst, size_t sz, const char *fmt, va_list ap) {
   FILE f = {-1, EOF};
   int ret;
   f.obuf = dst;
-  f.osize = sz - 1;
+  // sz == 0 (and dst may be NULL) is the standard "measure length" idiom: count
+  // only, write nothing. Guard against the sz - 1 underflow and the terminator
+  // store into a NULL/zero-size buffer (which faults once the MPU is active).
+  f.osize = (sz > 0) ? (sz - 1) : 0;
   ret = vfprintf(&f, fmt, ap);
-  dst[f.olen] = '\0';
+  if (dst != NULL && sz > 0)
+    dst[f.olen] = '\0';
   return ret;
 }
 

--- a/stdio.c
+++ b/stdio.c
@@ -192,7 +192,23 @@ int fclose(FILE *fp) {
     free(fp->ibuf);
   if (fp->oown)
     free(fp->obuf);
-  free(fp);
+  /* fclose(stdout) is legal (and used by gcc-torture printf tests after
+   * freopen): the standard streams are statics in this file, not heap
+   * chunks — free(&_stdout) inserted .data into the allocator's free list
+   * and corrupted it (HardFault on the next malloc/free walk).  Mark the
+   * static stream closed instead of freeing it. */
+  if (fp == stdin || fp == stdout || fp == stderr) {
+    fp->fd = -1;
+    fp->ibuf = NULL;
+    fp->obuf = NULL;
+    fp->iown = 0;
+    fp->oown = 0;
+    fp->isize = 0;
+    fp->osize = 0;
+    stdio_reset_stream(fp);
+  } else {
+    free(fp);
+  }
   return ret;
 }
 

--- a/stdio.c
+++ b/stdio.c
@@ -213,6 +213,21 @@ int fclose(FILE *fp) {
 }
 
 int fflush(FILE *fp) {
+  /* POSIX: fflush(NULL) flushes all open output streams.  Without this
+   * check fp==NULL dereferenced address 0 — on this MMU-less target that
+   * is the SSRAM alias of the kernel image, so fp->fd/obuf/olen read
+   * kernel vector-table words and the "flush" became a wild multi-MB
+   * write of the kernel image to the console (toybox xexit calls
+   * fflush(0) after every builtin). Match exit()'s semantics and flush
+   * the buffered standard streams. */
+  if (fp == NULL) {
+    int r = 0;
+    if (fflush(stdout))
+      r = EOF;
+    if (fflush(stderr))
+      r = EOF;
+    return r;
+  }
   if (fp->fd < 0)
     return 0;
   if (write(fp->fd, fp->obuf, fp->olen) != fp->olen)

--- a/stdio.c
+++ b/stdio.c
@@ -13,7 +13,14 @@
 static char _ibuf[BUFSIZ], _obuf[BUFSIZ], _ebuf[BUFSIZ];
 static FILE _stdin = {0, EOF, _ibuf, NULL, BUFSIZ, 0};
 static FILE _stdout = {1, EOF, NULL, _obuf, 0, BUFSIZ};
-static FILE _stderr = {2, EOF, NULL, _ebuf, 0, 1};
+/* stderr is LINE-buffered (osize = BUFSIZ), not unbuffered (osize = 1).
+ * fputc() already flushes on '\n' or when the buffer fills, so diagnostics
+ * still appear promptly, but a whole line is emitted in ONE block write()
+ * instead of one write(fd,&c,1) syscall per character. The latter loses ~half
+ * its bytes on this target (rapid single-byte writes outrun the console/FS
+ * write path), which was scrambling every error message to every-other-char
+ * (e.g. tcc's compile errors became unreadable). Block writes are reliable. */
+static FILE _stderr = {2, EOF, NULL, _ebuf, 0, BUFSIZ};
 FILE *stdin = &_stdin;
 FILE *stdout = &_stdout;
 FILE *stderr = &_stderr;

--- a/stdio.h
+++ b/stdio.h
@@ -20,6 +20,10 @@
 #define STDOUT_FILENO 1
 #define STDERR_FILENO 2
 
+#define P_tmpdir "/tmp"
+#define L_tmpnam 32
+#define TMP_MAX 16384
+
 #define putc(c, fp) (fputc(c, fp))
 #define getc(fp) (fgetc(fp))
 
@@ -43,11 +47,13 @@ extern FILE *stdout;
 extern FILE *stderr;
 
 FILE *fopen(const char *path, const char *mode);
+FILE *freopen(const char *path, const char *mode, FILE *fp);
 int fclose(FILE *fp);
 int fflush(FILE *fp);
 void setbuf(FILE *fp, char *buf);
 
 FILE *tmpfile(void);
+char *tmpnam(char *buffer);
 int fputc(int c, FILE *fp);
 int putchar(int c);
 int printf(const char *fmt, ...);

--- a/stdio.h
+++ b/stdio.h
@@ -40,7 +40,10 @@ typedef struct {
 } FILE;
 
 
-#define BUFSIZ 1024
+/* Embedded target: 256 B is plenty for line/block buffering and keeps the
+ * three static stream buffers (stdin/stdout/stderr) + every fopen buffer small.
+ * Trade: slightly more read/write syscalls on bulk I/O. */
+#define BUFSIZ 256
 
 extern FILE *stdin;
 extern FILE *stdout;

--- a/stdlib.c
+++ b/stdlib.c
@@ -87,7 +87,15 @@ int system(char *cmd) {
   return ret;
 }
 
-static void *atexit_func[ATEXIT_MAX];
+/* ISO C forbids direct conversion between function pointers and void *.
+ * Use a union to store arbitrary handler types without violating pedantic. */
+typedef union {
+  void (*as_void)(void);
+  void (*as_exit)(int, void *);
+  void *as_ptr;
+} atexit_handler;
+
+static atexit_handler atexit_func[ATEXIT_MAX];
 static void *atexit_arg[ATEXIT_MAX];
 static int atexit_cnt;
 void *__yasos_fini_table;
@@ -98,7 +106,7 @@ extern void __call_with_got(void (*func)(void), void *got_base);
 int on_exit(void (*func)(int, void *), void *arg) {
   if (atexit_cnt >= ATEXIT_MAX)
     return -1;
-  atexit_func[atexit_cnt] = (void *)func;
+  atexit_func[atexit_cnt].as_exit = func;
   atexit_arg[atexit_cnt] = arg;
   atexit_cnt++;
   return 0;
@@ -107,7 +115,7 @@ int on_exit(void (*func)(int, void *), void *arg) {
 int atexit(void (*func)(void)) {
   if (atexit_cnt >= ATEXIT_MAX)
     return -1;
-  atexit_func[atexit_cnt] = (void *)func;
+  atexit_func[atexit_cnt].as_void = func;
   atexit_arg[atexit_cnt] = 0;
   atexit_cnt++;
   return 0;
@@ -134,8 +142,7 @@ void __libc_finalize_and_exit(int status) {
   /* Run atexit/on_exit handlers (LIFO) */
   while (atexit_cnt > 0) {
     --atexit_cnt;
-    ((void (*)(int, void *))atexit_func[atexit_cnt])(status,
-                                                     atexit_arg[atexit_cnt]);
+    (atexit_func[atexit_cnt].as_exit)(status, atexit_arg[atexit_cnt]);
   }
   fflush(stdout);
   fflush(stderr);

--- a/stdlib.c
+++ b/stdlib.c
@@ -35,18 +35,7 @@ int abs(int n) {
 }
 
 double atof(const char *str) {
-  double result = 0.0;
-  int sign = 1;
-  while (*str && *str != ' ' && *str != '\t') {
-    if (*str == '-')
-      sign = -1;
-    else if (*str >= '0' && *str <= '9')
-      result = result * 10.0 + (*str - '0');
-    else
-      break;
-    str++;
-  }
-  return result * sign;
+  return strtod(str, NULL);
 }
 
 long int labs(long int n) {
@@ -170,7 +159,6 @@ unsigned long long int strtoull(const char *nptr, char **endptr, int base) {
 
 double strtod(const char *nptr, char **endptr) {
   const char *s = nptr;
-  double result = 0.0;
   int sign = 1;
 
   /* Skip leading whitespace */
@@ -185,50 +173,92 @@ double strtod(const char *nptr, char **endptr) {
     s++;
   }
 
+  /* Accumulate the mantissa as an exact 64-bit integer and track the decimal
+   * exponent separately; scale once at the end with correctly-rounded IEEE
+   * multiplies/divides by exact powers of ten.  A digit-by-digit
+   * `frac *= 0.1` accumulation is ~1 ulp low on most fractions (0.1 is not
+   * representable), which broke FP literal parsing in the on-target tcc:
+   * "1.25" parsed to the double just below 1.25. */
+  unsigned long long mant = 0;
+  int dec_exp = 0;
+  int digits = 0;
+
   /* Integer part */
   while (*s >= '0' && *s <= '9') {
-    result = result * 10.0 + (*s - '0');
+    if (mant != 0 || *s != '0') {
+      if (digits < 19) {
+        mant = mant * 10 + (unsigned long long)(*s - '0');
+        digits++;
+      } else {
+        dec_exp++;
+      }
+    }
     s++;
   }
 
   /* Fractional part */
   if (*s == '.') {
-    double frac = 0.1;
     s++;
     while (*s >= '0' && *s <= '9') {
-      result += (*s - '0') * frac;
-      frac *= 0.1;
+      if (mant == 0 && *s == '0') {
+        dec_exp--; /* leading fractional zero: pure scale-down */
+      } else if (digits < 19) {
+        mant = mant * 10 + (unsigned long long)(*s - '0');
+        digits++;
+        dec_exp--;
+      }
       s++;
     }
   }
 
-  /* Exponent part */
+  /* Exponent part (only if at least one digit follows the 'e'/sign) */
   if (*s == 'e' || *s == 'E') {
+    const char *e_start = s;
     s++;
     int exp_sign = 1;
-    int exp_val = 0;
     if (*s == '-') {
       exp_sign = -1;
       s++;
     } else if (*s == '+') {
       s++;
     }
-    while (*s >= '0' && *s <= '9') {
-      exp_val = exp_val * 10 + (*s - '0');
-      s++;
+    if (*s >= '0' && *s <= '9') {
+      int exp_val = 0;
+      while (*s >= '0' && *s <= '9') {
+        if (exp_val < 100000)
+          exp_val = exp_val * 10 + (*s - '0');
+        s++;
+      }
+      dec_exp += exp_sign * exp_val;
+    } else {
+      s = e_start; /* bare 'e' is not part of the number */
     }
-    double power = 1.0;
-    for (int i = 0; i < exp_val; i++)
-      power *= 10.0;
-    if (exp_sign > 0)
-      result *= power;
-    else
-      result /= power;
+  }
+
+  /* 10^0..10^22 are exactly representable as doubles, so a single multiply
+   * or divide below is correctly rounded.  Larger exponents step in chunks
+   * (rare; may cost an extra rounding). */
+  static const double pow10tab[23] = {1e0,  1e1,  1e2,  1e3,  1e4,  1e5,  1e6,  1e7,
+                                      1e8,  1e9,  1e10, 1e11, 1e12, 1e13, 1e14, 1e15,
+                                      1e16, 1e17, 1e18, 1e19, 1e20, 1e21, 1e22};
+  double result = (double)mant;
+  if (result != 0.0) {
+    int e = dec_exp;
+    while (e > 0) {
+      int step = e > 22 ? 22 : e;
+      result *= pow10tab[step];
+      e -= step;
+    }
+    while (e < 0) {
+      int step = e < -22 ? 22 : -e;
+      result /= pow10tab[step];
+      e += step;
+    }
   }
 
   if (endptr)
     *endptr = (char *)s;
-  return result * sign;
+  return sign < 0 ? -result : result;
 }
 
 float strtof(const char *nptr, char **endptr) {

--- a/stdlib.c
+++ b/stdlib.c
@@ -6,7 +6,9 @@
 
 #include <stdio.h>
 
-#define ATEXIT_MAX 32
+/* 16 atexit handlers is plenty for the programs we run; each unused slot is
+ * a function pointer + an arg pointer in per-process .bss. */
+#define ATEXIT_MAX 16
 
 char **environ;
 

--- a/stdlib.h
+++ b/stdlib.h
@@ -38,6 +38,8 @@ void srand(unsigned int seed);
 int rand(void);
 
 double strtod(const char *nptr, char **endptr);
+float strtof(const char *nptr, char **endptr);
+long double strtold(const char *nptr, char **endptr);
 long long strtoll(const char *str, char **endptr, int base);
 unsigned long long int strtoull(const char *nptr, char **endptr, int base);
 

--- a/string.c
+++ b/string.c
@@ -28,6 +28,12 @@ void *__memchr_c(const void *src, int c, long n) {
   return n ? (void *)s : 0;
 }
 
+#undef memchr
+
+void *memchr(const void *src, int c, long n) {
+  return __memchr_c(src, c, n);
+}
+
 void *memset(void *ptr, int value, size_t num) {
   uint8_t *p = (uint8_t *)ptr;
   for (size_t i = 0; i < num; ++i)
@@ -41,6 +47,11 @@ void *memcpy(void *dst, const void *src, size_t n) {
   for (size_t i = 0; i < n; ++i)
     d[i] = s[i];
   return dst;
+}
+
+void *mempcpy(void *dst, const void *src, size_t n) {
+  memcpy(dst, src, n);
+  return (uint8_t *)dst + n;
 }
 
 void *memccpy(void *dst, const void *src, int c, size_t n) {

--- a/string.h
+++ b/string.h
@@ -43,3 +43,5 @@ char *stpcpy(char *dst, const char *src);
 char *stpncpy(char *dst, const char *src, size_t n);
 
 char *strpbrk(const char *s, const char *accept);
+int strcasecmp(const char *s1, const char *s2);
+int strncasecmp(const char *s1, const char *s2, size_t n);

--- a/string.h
+++ b/string.h
@@ -8,6 +8,7 @@
 #include <stddef.h>
 
 void *memcpy(void *dst, const void *src, size_t n);
+void *mempcpy(void *dst, const void *src, size_t n);
 void *memccpy(void *dst, const void *src, int c, size_t n);
 void *memmove(void *dst, const void *src, size_t n);
 void *memset(void *s, int v, size_t n);

--- a/sys/klog.c
+++ b/sys/klog.c
@@ -1,0 +1,31 @@
+/*
+ Copyright (c) 2025 Mateusz Stadnik <matgla@live.com>
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+#include "sys/klog.h"
+#include "sys/syscall.h"
+
+int klog_ctl(int enable) {
+  const klog_ctl_context context = {
+      .enable = enable,
+  };
+  return trigger_syscall(sys_klog_ctl, &context);
+}

--- a/sys/klog.h
+++ b/sys/klog.h
@@ -1,0 +1,29 @@
+/*
+ Copyright (c) 2025 Mateusz Stadnik <matgla@live.com>
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+#pragma once
+
+/* Control kernel log output on the console UART.
+   enable=1: allow kernel log output (default).
+   enable=0: suppress kernel log output.
+   Returns 0 on success. */
+int klog_ctl(int enable);

--- a/sys/perf.c
+++ b/sys/perf.c
@@ -1,0 +1,103 @@
+/*
+ Copyright (c) 2025 Mateusz Stadnik <matgla@live.com>
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+#include "sys/perf.h"
+#include "sys/syscall.h"
+
+#include <stdio.h>
+
+int perf_dump(perf_syscall_entry *entries, int max_entries, int *num_entries, int reset) {
+  perf_dump_context context = {
+      .entries = entries,
+      .max_entries = max_entries,
+      .num_entries = num_entries,
+      .reset = reset,
+  };
+  return trigger_syscall(sys_perf_dump, &context);
+}
+
+static const char *syscall_name(unsigned int id) {
+  switch (id) {
+    case sys_open: return "open";
+    case sys_close: return "close";
+    case sys_read: return "read";
+    case sys_write: return "write";
+    case sys_fstat: return "fstat";
+    case sys_stat: return "stat";
+    case sys_lseek: return "lseek";
+    case sys_mmap: return "mmap";
+    case sys_munmap: return "munmap";
+    case sys_mremap: return "mremap";
+    case sys_access: return "access";
+    case sys_getcwd: return "getcwd";
+    case sys_realpath: return "realpath";
+    case sys_fcntl: return "fcntl";
+    case sys_execve: return "execve";
+    case sys_exit: return "exit";
+    case sys_vfork: return "vfork";
+    case sys_waitpid: return "waitpid";
+    case sys_getpid: return "getpid";
+    case sys_dlopen: return "dlopen";
+    case sys_dlclose: return "dlclose";
+    case sys_dlsym: return "dlsym";
+    case sys_times: return "times";
+    case sys_ioctl: return "ioctl";
+    case sys_mkdir: return "mkdir";
+    case sys_unlink: return "unlink";
+    case sys_isatty: return "isatty";
+    case sys_getdents: return "getdents";
+    case sys_gettimeofday: return "gettimeofday";
+    case sys_nanosleep: return "nanosleep";
+    case sys_chdir: return "chdir";
+    case sys_time: return "time";
+    case sys_mprotect: return "mprotect";
+    case sys_dup: return "dup";
+    case sys_ftruncate: return "ftruncate";
+    default: return NULL;
+  }
+}
+
+void perf_dump_print(int reset) {
+  perf_syscall_entry entries[64];
+  int num = 0;
+  if (perf_dump(entries, 64, &num, reset) != 0) {
+    fprintf(stderr, "perf_dump: syscall failed\n");
+    return;
+  }
+  if (num == 0) {
+    fprintf(stderr, "# perf: no syscall data (profiling disabled?)\n");
+    return;
+  }
+  fprintf(stderr, "# perf: syscall profile (%d entries)%s\n", num, reset ? " [reset]" : "");
+  fprintf(stderr, "# %-16s %8s %12s %12s %12s\n", "syscall", "calls", "total_cyc", "max_cyc", "avg_cyc");
+  for (int i = 0; i < num; i++) {
+    const char *name = syscall_name(entries[i].syscall_id);
+    unsigned int avg = entries[i].call_count ? entries[i].total_cycles / entries[i].call_count : 0;
+    if (name) {
+      fprintf(stderr, "# %-16s %8u %12u %12u %12u\n",
+              name, entries[i].call_count, entries[i].total_cycles, entries[i].max_cycles, avg);
+    } else {
+      fprintf(stderr, "# syscall_%-7u %8u %12u %12u %12u\n",
+              entries[i].syscall_id, entries[i].call_count, entries[i].total_cycles, entries[i].max_cycles, avg);
+    }
+  }
+}

--- a/sys/perf.h
+++ b/sys/perf.h
@@ -1,0 +1,36 @@
+/*
+ Copyright (c) 2025 Mateusz Stadnik <matgla@live.com>
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+#pragma once
+
+#include "sys/syscall.h"
+
+/* Retrieve per-syscall cycle count profile from the kernel.
+ * entries:     caller-allocated array for results
+ * max_entries: size of the array
+ * num_entries: receives the actual number of entries written
+ * reset:       non-zero to reset counters after reading
+ * Returns 0 on success. */
+int perf_dump(perf_syscall_entry *entries, int max_entries, int *num_entries, int reset);
+
+/* Pretty-print the syscall profile to stderr and optionally reset counters. */
+void perf_dump_print(int reset);

--- a/sys/syscall.h
+++ b/sys/syscall.h
@@ -301,8 +301,34 @@ typedef enum SystemCall {
   sys_access,
   sys_prlimit,
   sys_mremap,
+  sys_klog_ctl,
+  sys_ftruncate,
+  sys_perf_dump,
   SYSCALL_COUNT,
 } SystemCall;
+
+typedef struct klog_ctl_context {
+  int enable;
+} klog_ctl_context;
+
+typedef struct ftruncate_context {
+  int fd;
+  off_t length;
+} ftruncate_context;
+
+typedef struct perf_syscall_entry {
+  unsigned int syscall_id;
+  unsigned int call_count;
+  unsigned int total_cycles;
+  unsigned int max_cycles;
+} perf_syscall_entry;
+
+typedef struct perf_dump_context {
+  perf_syscall_entry *entries;
+  int max_entries;
+  int *num_entries;
+  int reset;
+} perf_dump_context;
 
 int trigger_syscall(int number, const void *args);
 

--- a/sys/types.h
+++ b/sys/types.h
@@ -5,10 +5,20 @@
 
 #pragma once
 
-#include <endian.h>
-#include <fcntl.h>
-#include <inttypes.h>
+/* It used to also pull in <fcntl.h> and <inttypes.h>, neither of whose symbols
+   are used by this header or expected from <sys/types.h> -- a layering leak
+   that forced every TU including <sys/types.h> (i.e. almost all of them) to
+   open + read + tokenize two extra headers (fcntl.h alone is ~1.8 KB); those
+   are dropped.  We keep:
+     <stdint.h> -- fixed-width / intptr_t types used below;
+     <stddef.h> -- size_t, which consumers expect <sys/types.h> to provide;
+     <endian.h> -- BSD-style BYTE_ORDER/LITTLE_ENDIAN macros that third-party
+                   code (e.g. mibench sha.c) relies on seeing transitively via
+                   <sys/types.h>; removing it silently disables their byte-swap
+                   paths, so it stays on purpose. */
+#include <stdint.h>
 #include <stddef.h>
+#include <endian.h>
 
 typedef uint32_t dev_t;
 typedef uint16_t gid_t;
@@ -19,6 +29,11 @@ typedef uint16_t uid_t;
 typedef intptr_t ssize_t;
 typedef long long time_t;
 typedef long useconds_t;
+
+/* POSIX types: these live here (not in <fcntl.h>) so any TU that includes
+   <sys/types.h> gets them without dragging in the open()/fcntl() surface. */
+typedef int32_t pid_t;
+typedef signed long off_t;
 
 typedef signed long ino_t;
 typedef uint32_t uid32_t;

--- a/sys/types.h
+++ b/sys/types.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <endian.h>
 #include <fcntl.h>
 #include <inttypes.h>
 #include <stddef.h>

--- a/syscalls.c
+++ b/syscalls.c
@@ -33,6 +33,7 @@
 
 #include <sys/time.h>
 #include <sys/times.h>
+#include <sys/stat.h>
 
 #include "sys/syscall.h"
 #include <stdio.h>
@@ -462,11 +463,82 @@ int fcntl(int fd, int op, ...) {
 }
 
 char *realpath(const char *path, char *resolved_path) {
-  const realpath_context context = {
-      .path = path,
-      .resolved_path = resolved_path,
-  };
-  trigger_syscall(sys_realpath, &context);
+  char buf[PATH_MAX];
+  const char *p;
+  char *q;
+  struct stat st;
+
+  if (!path || !*path) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  /* Build absolute path */
+  if (path[0] != '/') {
+    if (!getcwd(buf, sizeof(buf)))
+      return NULL;
+    q = buf + strlen(buf);
+    if (q > buf && q[-1] != '/')
+      *q++ = '/';
+  } else {
+    buf[0] = '/';
+    q = buf + 1;
+  }
+
+  /* Canonicalize: collapse //, /., /.. */
+  p = path;
+  while (*p) {
+    if (*p == '/') {
+      /* skip redundant slashes */
+      while (*p == '/') p++;
+      /* ensure single slash separator (unless at start of buf) */
+      if (q > buf && q[-1] != '/')
+        *q++ = '/';
+      continue;
+    }
+    if (p[0] == '.' && (p[1] == '/' || p[1] == '\0')) {
+      /* skip "." component */
+      p += 1;
+      continue;
+    }
+    if (p[0] == '.' && p[1] == '.' && (p[2] == '/' || p[2] == '\0')) {
+      /* ".." - go up one level */
+      p += 2;
+      if (q > buf + 1) {
+        q--;
+        while (q > buf && q[-1] != '/') q--;
+      }
+      continue;
+    }
+    /* copy path component */
+    while (*p && *p != '/')
+      *q++ = *p++;
+    if ((size_t)(q - buf) >= sizeof(buf) - 1) {
+      errno = ENAMETOOLONG;
+      return NULL;
+    }
+  }
+
+  /* ensure at least "/" */
+  if (q == buf)
+    *q++ = '/';
+  /* remove trailing slash (except root) */
+  if (q > buf + 1 && q[-1] == '/')
+    q--;
+  *q = '\0';
+
+  /* verify path exists */
+  if (stat(buf, &st) < 0)
+    return NULL;
+
+  if (!resolved_path) {
+    resolved_path = (char *)malloc(strlen(buf) + 1);
+    if (!resolved_path) {
+      errno = ENOMEM;
+      return NULL;
+    }
+  }
+  strcpy(resolved_path, buf);
   return resolved_path;
 }
 

--- a/syscalls.c
+++ b/syscalls.c
@@ -39,6 +39,10 @@
 
 #include <limits.h>
 
+/* malloc vfork save/restore (defined in malloc.c) */
+extern void __malloc_vfork_save(void);
+extern void __malloc_vfork_restore(void);
+
 #ifdef YASLIBC_ARM_SVC_TRIGGER
 inline void __attribute__((naked))
 trigger_supervisor_call(int number, const void *args, syscall_result *result) {
@@ -90,8 +94,8 @@ int close(int fd) {
 }
 
 // suppress noreturn that returns
-extern void __libc_finalize_and_exit(int status);
-void exit(int status) {
+extern __attribute__((noreturn)) void __libc_finalize_and_exit(int status);
+void __attribute__((noreturn)) exit(int status) {
   __libc_finalize_and_exit(status);
 }
 
@@ -158,7 +162,13 @@ pid_t _vfork_process(void *lr, void *r9, void *sp, uint32_t is_fpu_used) {
       .sp = sp,
       .is_fpu_used = is_fpu_used,
   };
-  return trigger_syscall(sys_vfork, &context);
+  /* Save malloc pool state before child runs on shared address space.
+     The child may allocate/free, corrupting the bump-allocator position.
+     Restore after the syscall returns (always in the parent). */
+  __malloc_vfork_save();
+  pid_t result = trigger_syscall(sys_vfork, &context);
+  __malloc_vfork_restore();
+  return result;
 }
 
 int unlink(const char *pathname) {

--- a/syscalls.c
+++ b/syscalls.c
@@ -20,6 +20,7 @@
 
 #include <sys/types.h>
 
+#include <fcntl.h> /* AT_FDCWD */
 #include <errno.h>
 #include <regex.h>
 #include <stdarg.h>

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -22,6 +22,7 @@ $(LIBC_STATIC): $(LIBC_SRCS)
 	$(MAKE) -C .. CC=$(CC)
 
 $(LIBC_TEST_STATIC): $(LIBC_STATIC)
+	mkdir -p build
 	cp $(LIBC_STATIC) $(LIBC_TEST_STATIC)
 	./rename_symbols.sh $(LIBC_TEST_STATIC)
 $(TARGET): $(OBJS) $(LIBC_TEST_STATIC)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,16 @@
 CC = gcc
-CFLAGS = -Wall -pedantic -g -std=c11
+# _DEFAULT_SOURCE exposes the host glibc POSIX/BSD extensions (e.g. P_tmpdir)
+# that strict -std=c11 otherwise hides, matching what the yasos libc headers
+# provide unconditionally.
+CFLAGS = -Wall -pedantic -g -std=c11 -D_DEFAULT_SOURCE
 
-SRCS = $(wildcard *.c)
+# Standalone host reproducers: each has its own main() and #includes malloc.c
+# directly, so they cannot be linked into the unified utest binary (duplicate
+# main / allocator symbols). They are slow O(n^2)-audit stress drivers meant to
+# be run on demand via `make stress`, not as part of the routine suite.
+STANDALONE = malloc_overlap_repro malloc_overlap_devbackend
+
+SRCS = $(filter-out $(addsuffix .c,$(STANDALONE)), $(wildcard *.c))
 OBJS = $(patsubst %.c, build/%.o, $(SRCS))
 
 
@@ -32,6 +41,16 @@ test: $(TARGET)
 	./$(TARGET)
 
 build_tests: $(TARGET)
+
+# Standalone allocator stress reproducers (slow; run on demand).
+build/%: %.c
+	mkdir -p build
+	$(CC) $(CFLAGS) -O2 $< -o $@
+
+stress: $(addprefix build/, $(STANDALONE))
+	@for t in $(addprefix build/, $(STANDALONE)); do \
+	  echo "------------ $$t ------------"; ./$$t || exit 1; \
+	done
 
 clean:
 	rm -rf build

--- a/tests/bitops_tests.c
+++ b/tests/bitops_tests.c
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 Mateusz Stadnik <matgla@live.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <limits.h>
+
+#include "utest.h"
+
+int sut_ffs(int value);
+int sut_ffsl(long value);
+int sut_ffsll(long long value);
+int sut___clzsi2(unsigned int value);
+int sut___ctzsi2(unsigned int value);
+int sut___paritysi2(unsigned int value);
+int sut___popcountsi2(unsigned int value);
+int sut___clzdi2(unsigned long long value);
+int sut___ctzdi2(unsigned long long value);
+int sut___popcountdi2(unsigned long long value);
+int sut___paritydi2(unsigned long long value);
+
+UTEST(bitops_tests, first_set_bit_family) {
+  ASSERT_EQ(0, sut_ffs(0));
+  ASSERT_EQ(1, sut_ffs(1));
+  ASSERT_EQ(4, sut_ffs(0x28));
+
+  ASSERT_EQ(0, sut_ffsl(0));
+  ASSERT_EQ(3, sut_ffsl(4));
+  ASSERT_EQ((int)(sizeof(long) * CHAR_BIT - 1),
+            sut_ffsl((long)(1UL << ((sizeof(long) * CHAR_BIT) - 2))));
+
+  ASSERT_EQ(0, sut_ffsll(0));
+  ASSERT_EQ(2, sut_ffsll(2));
+  ASSERT_EQ(64, sut_ffsll(1ULL << 63));
+}
+
+UTEST(bitops_tests, clz_and_ctz_helpers) {
+  ASSERT_EQ((int)(sizeof(unsigned int) * CHAR_BIT), sut___clzsi2(0));
+  ASSERT_EQ((int)(sizeof(unsigned int) * CHAR_BIT - 1), sut___clzsi2(1));
+  ASSERT_EQ(0, sut___clzsi2(1U << ((sizeof(unsigned int) * CHAR_BIT) - 1)));
+  ASSERT_EQ((int)(sizeof(unsigned int) * CHAR_BIT), sut___ctzsi2(0));
+  ASSERT_EQ(0, sut___ctzsi2(1));
+  ASSERT_EQ(7, sut___ctzsi2(1U << 7));
+
+  ASSERT_EQ((int)(sizeof(unsigned long long) * CHAR_BIT), sut___clzdi2(0));
+  ASSERT_EQ((int)(sizeof(unsigned long long) * CHAR_BIT - 1), sut___clzdi2(1));
+  ASSERT_EQ(0, sut___clzdi2(1ULL << 63));
+  ASSERT_EQ((int)(sizeof(unsigned long long) * CHAR_BIT), sut___ctzdi2(0));
+  ASSERT_EQ(0, sut___ctzdi2(1));
+  ASSERT_EQ(17, sut___ctzdi2(1ULL << 17));
+}
+
+UTEST(bitops_tests, popcount_and_parity_helpers) {
+  ASSERT_EQ(0, sut___popcountsi2(0));
+  ASSERT_EQ(4, sut___popcountsi2(0xF0));
+  ASSERT_EQ(0, sut___paritysi2(0));
+  ASSERT_EQ(1, sut___paritysi2(0x07));
+  ASSERT_EQ(0, sut___paritysi2(0x0F));
+
+  ASSERT_EQ(0, sut___popcountdi2(0));
+  ASSERT_EQ(32, sut___popcountdi2(0xF0F0F0F0F0F0F0F0ULL));
+  ASSERT_EQ(0, sut___paritydi2(0));
+  ASSERT_EQ(1, sut___paritydi2(0x1111111111111111ULL));
+  ASSERT_EQ(0, sut___paritydi2(0x3333333333333333ULL));
+}

--- a/tests/bitops_tests.c
+++ b/tests/bitops_tests.c
@@ -75,6 +75,7 @@ UTEST(bitops_tests, popcount_and_parity_helpers) {
   ASSERT_EQ(0, sut___popcountdi2(0));
   ASSERT_EQ(32, sut___popcountdi2(0xF0F0F0F0F0F0F0F0ULL));
   ASSERT_EQ(0, sut___paritydi2(0));
-  ASSERT_EQ(1, sut___paritydi2(0x1111111111111111ULL));
+  /* 15 set bits -> odd parity. (0x1111...1111 has 16 set bits, i.e. even.) */
+  ASSERT_EQ(1, sut___paritydi2(0x1111111111111110ULL));
   ASSERT_EQ(0, sut___paritydi2(0x3333333333333333ULL));
 }

--- a/tests/complex_tests.c
+++ b/tests/complex_tests.c
@@ -1,0 +1,84 @@
+// Copyright (c) 2025 Mateusz Stadnik <matgla@live.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "utest.h"
+
+typedef union {
+  float _Complex value;
+  struct {
+    float real;
+    float imag;
+  } parts;
+} float_complex_parts;
+
+typedef union {
+  double _Complex value;
+  struct {
+    double real;
+    double imag;
+  } parts;
+} double_complex_parts;
+
+typedef union {
+  long double _Complex value;
+  struct {
+    long double real;
+    long double imag;
+  } parts;
+} long_double_complex_parts;
+
+float _Complex sut_conjf(float _Complex value);
+double _Complex sut_conj(double _Complex value);
+long double _Complex sut_conjl(long double _Complex value);
+float sut_crealf(float _Complex value);
+double sut_creal(double _Complex value);
+long double sut_creall(long double _Complex value);
+float sut_cimagf(float _Complex value);
+double sut_cimag(double _Complex value);
+long double sut_cimagl(long double _Complex value);
+
+UTEST(complex_tests, conj_returns_complex_conjugate) {
+  float_complex_parts float_value;
+  double_complex_parts double_value;
+  long_double_complex_parts long_double_value;
+
+  float_value.value = sut_conjf(1.5f + 2.25fi);
+  ASSERT_EQ(1.5f, float_value.parts.real);
+  ASSERT_EQ(-2.25f, float_value.parts.imag);
+
+  double_value.value = sut_conj(3.0 + 4.5i);
+  ASSERT_EQ(3.0, double_value.parts.real);
+  ASSERT_EQ(-4.5, double_value.parts.imag);
+
+  long_double_value.value = sut_conjl(5.0L + 6.75iL);
+  ASSERT_EQ(5.0L, long_double_value.parts.real);
+  ASSERT_EQ(-6.75L, long_double_value.parts.imag);
+}
+
+UTEST(complex_tests, real_and_imag_extract_components) {
+  ASSERT_EQ(7.5f, sut_crealf(7.5f + 8.5fi));
+  ASSERT_EQ(8.5f, sut_cimagf(7.5f + 8.5fi));
+
+  ASSERT_EQ(9.25, sut_creal(9.25 + 10.75i));
+  ASSERT_EQ(10.75, sut_cimag(9.25 + 10.75i));
+
+  ASSERT_EQ(11.125L, sut_creall(11.125L + 12.875iL));
+  ASSERT_EQ(12.875L, sut_cimagl(11.125L + 12.875iL));
+}

--- a/tests/malloc_overlap_devbackend.c
+++ b/tests/malloc_overlap_devbackend.c
@@ -1,0 +1,208 @@
+/*
+ * Host reproducer #2 — models the DEVICE memory backend, not host mmap.
+ *
+ * The first reproducer used the host kernel's mmap/mremap, which spread
+ * allocations far apart (ASLR) and refuse in-place growth onto busy pages.
+ * The RP2350 yasos backend instead serves pages from a single fixed arena
+ * with a page bitmap, lowest-free-fit reuse, and in-place mremap extension
+ * (source/kernel/memory/heap/process_memory_pool.zig). That aggressive
+ * page reuse is the regime in which a freed region silently aliases a live
+ * one — the symptom seen on device (put_elf_sym writing into a live regalloc
+ * interval array).
+ *
+ * Here we shim mmap/munmap/mremap to a faithful port of that page allocator
+ * so the SAME malloc.c logic runs against the SAME backend semantics, and we
+ * assert no two live allocations ever overlap and content is never clobbered.
+ *
+ *   gcc -m32 -O2 -g -o /tmp/mor_dev malloc_overlap_devbackend.c && /tmp/mor_dev
+ */
+#define _GNU_SOURCE
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ---- device-like page arena (mirrors process_memory_pool.zig) ---- */
+#define DEV_PAGE 4096
+#define DEV_PAGES 8192            /* 32 MiB arena, like a generous PSRAM heap */
+static unsigned char dev_arena[DEV_PAGES * DEV_PAGE] __attribute__((aligned(DEV_PAGE)));
+static unsigned char dev_bitmap[DEV_PAGES];
+
+static long dev_pages_for(long len) { return (len + DEV_PAGE - 1) / DEV_PAGE; }
+
+/* lowest-free-fit, exactly like get_next_free_slot + allocate_pages */
+static void *dev_mmap(long len) {
+  long need = dev_pages_for(len);
+  if (need <= 0) return (void *)-1;
+  long i = 0;
+  while (i + need <= DEV_PAGES) {
+    long j = 0;
+    while (j < need && !dev_bitmap[i + j]) j++;
+    if (j == need) {
+      for (long k = 0; k < need; k++) dev_bitmap[i + k] = 1;
+      void *p = dev_arena + i * DEV_PAGE;
+      memset(p, 0, need * DEV_PAGE);
+      return p;
+    }
+    i += j + 1; /* skip past the busy page */
+  }
+  return (void *)-1; /* MAP_FAILED */
+}
+
+static long dev_index(void *addr) {
+  return ((unsigned char *)addr - dev_arena) / DEV_PAGE;
+}
+
+static int dev_munmap(void *addr, long len) {
+  long idx = dev_index(addr);
+  long n = dev_pages_for(len);
+  for (long k = 0; k < n; k++) dev_bitmap[idx + k] = 0;
+  return 0;
+}
+
+/* in-place extend only (flags ignored), mirrors try_extend_pages */
+static void *dev_mremap(void *addr, long old_len, long new_len, int flags) {
+  (void)flags;
+  long idx = dev_index(addr);
+  long oldn = dev_pages_for(old_len);
+  long newn = dev_pages_for(new_len);
+  if (newn <= oldn) return addr;
+  if (idx + newn > DEV_PAGES) return (void *)-1;
+  for (long k = oldn; k < newn; k++)
+    if (dev_bitmap[idx + k]) return (void *)-1;
+  for (long k = oldn; k < newn; k++) dev_bitmap[idx + k] = 1;
+  memset((unsigned char *)addr + oldn * DEV_PAGE, 0, (newn - oldn) * DEV_PAGE);
+  return addr;
+}
+
+/* shim the names malloc.c calls (it includes <sys/mman.h>; we pre-empt it) */
+#define MAP_PRIVATE 0
+#define MAP_ANONYMOUS 0
+#define PROT_READ 0
+#define PROT_WRITE 0
+#define MAP_FAILED ((void *)-1)
+#define mmap(addr, len, prot, flags, fd, off) dev_mmap((long)(len))
+#define munmap(addr, len) dev_munmap((addr), (long)(len))
+#define mremap(addr, old, new, flags) dev_mremap((addr), (long)(old), (long)(new), (flags))
+#define _SYS_MMAN_H 1 /* block the real header if pulled in */
+
+#define fprintf(...) (0)
+#define malloc  sut_malloc
+#define free    sut_free
+#define calloc  sut_calloc
+#define realloc sut_realloc
+#include "../malloc.c"
+#undef fprintf
+#undef malloc
+#undef free
+#undef calloc
+#undef realloc
+
+/* ---- live-allocation tracking + audit (same as reproducer #1) ---- */
+#define MAXLIVE 4096
+struct live { unsigned char *p; size_t n; unsigned char tag; };
+static struct live live[MAXLIVE];
+static int nlive;
+static unsigned char next_tag = 1;
+static unsigned long long ops;
+static int violations;
+
+static void audit(void) {
+  for (int i = 0; i < nlive; i++) {
+    for (size_t k = 0; k < live[i].n; k++) {
+      if (live[i].p[k] != live[i].tag) {
+        violations++;
+        printf("  !! CONTENT CLOBBER op %llu live[%d]=%p+%zu byte %zu=%02x exp %02x\n",
+               ops, i, (void *)live[i].p, live[i].n, k, live[i].p[k], live[i].tag);
+        break;
+      }
+    }
+    for (int j = i + 1; j < nlive; j++) {
+      unsigned char *a0 = live[i].p, *a1 = a0 + live[i].n;
+      unsigned char *b0 = live[j].p, *b1 = b0 + live[j].n;
+      if (a0 < b1 && b0 < a1) {
+        violations++;
+        printf("  !! OVERLAP op %llu live[%d]=%p+%zu vs live[%d]=%p+%zu\n",
+               ops, i, (void *)a0, live[i].n, j, (void *)b0, live[j].n);
+      }
+    }
+  }
+}
+
+static void do_alloc(size_t n) {
+  if (nlive >= MAXLIVE || n == 0) return;
+  unsigned char *p = sut_malloc(n);
+  if (!p) return;
+  unsigned char tag = next_tag++; if (!next_tag) next_tag = 1;
+  memset(p, tag, n);
+  live[nlive++] = (struct live){p, n, tag};
+  ops++; audit();
+}
+static void do_free(int idx) {
+  if (idx < 0 || idx >= nlive) return;
+  sut_free(live[idx].p);
+  live[idx] = live[--nlive];
+  ops++; audit();
+}
+static void do_realloc(int idx, size_t n) {
+  if (idx < 0 || idx >= nlive || n == 0) return;
+  unsigned char tag = live[idx].tag; size_t old = live[idx].n;
+  unsigned char *q = sut_realloc(live[idx].p, n);
+  if (!q) return;
+  size_t chk = old < n ? old : n;
+  for (size_t k = 0; k < chk; k++)
+    if (q[k] != tag) { violations++;
+      printf("  !! REALLOC LOST DATA op %llu byte %zu=%02x exp %02x\n", ops, k, q[k], tag);
+      break; }
+  memset(q, tag, n);
+  live[idx].p = q; live[idx].n = n;
+  ops++; audit();
+}
+
+static unsigned long rng_state = 1;
+static unsigned rng(void) { rng_state = rng_state * 1103515245 + 12345; return (rng_state >> 16) & 0x7fff; }
+
+int main(void) {
+  setvbuf(stdout, NULL, _IONBF, 0);
+  printf("device-backend reproducer (void*=%zu mhdr=%zu free_node=%zu arena=%dMiB)\n",
+         sizeof(void *), sizeof(struct mhdr), sizeof(struct free_node),
+         (DEV_PAGES * DEV_PAGE) >> 20);
+
+  /* Phase 1: random mixed, biased small with periodic large (interval arrays,
+     symtab grow into the >=4096 large path). */
+  for (int seed = 1; seed <= 6 && violations < 20; seed++) {
+    rng_state = 0x1000 * seed + 7;
+    for (int it = 0; it < 8000 && violations < 20; it++) {
+      unsigned r = rng() % 100;
+      if (r < 45) {
+        size_t n = (rng() % 100 < 85) ? 8 + rng() % 400 : 4097 + rng() % 24000;
+        do_alloc(n);
+      } else if (r < 70 && nlive) {
+        do_realloc(rng() % nlive, 8 + rng() % 30000); /* span small<->large */
+      } else if (nlive) {
+        do_free(rng() % nlive);
+      }
+    }
+    while (nlive) do_free(nlive - 1);
+  }
+
+  /* Phase 2: tcc-like — long-lived growers (large, realloc-extended) amid a
+     churn of small allocs and frees, the exact shape that aliased on device. */
+  {
+    rng_state = 0xBEEF;
+    for (int g = 0; g < 5; g++) do_alloc(2048);
+    for (int round = 0; round < 12000 && violations < 20; round++) {
+      int burst = 1 + rng() % 6;
+      for (int b = 0; b < burst; b++) do_alloc(8 + rng() % 300);
+      if (nlive > 12 && (rng() & 1)) do_free(5 + rng() % (nlive - 5));
+      if (rng() % 3 == 0 && nlive > 0)
+        do_realloc(rng() % (nlive < 5 ? nlive : 5), 2048 + (round / 20) * 64 + rng() % 256);
+    }
+    while (nlive) do_free(nlive - 1);
+  }
+
+  printf("\nTotal ops: %llu   Violations: %d\n", ops, violations);
+  if (violations) { printf("REPRODUCED on host (device-backend model).\n"); return 1; }
+  printf("No overlap/corruption with device-backend model + this pattern.\n");
+  return 0;
+}

--- a/tests/malloc_overlap_repro.c
+++ b/tests/malloc_overlap_repro.c
@@ -1,0 +1,213 @@
+/*
+ * Standalone host reproducer for the device heap corruption seen on RP2350
+ * while self-hosted armv8m-tcc compiles 90_struct-init.c:
+ *
+ *   A live regalloc interval array was found (via DWT watchpoint) being
+ *   overwritten by put_elf_sym (symtab section) and the IR operand pool —
+ *   i.e. two *distinct, simultaneously-live* tcc_malloc/tcc_realloc
+ *   allocations physically overlapped on the PSRAM heap.
+ *
+ * tcc_malloc just wraps the libc allocator (libs/libc/malloc.c). This test
+ * compiles that exact allocator and checks the invariant the device violated:
+ *   - no two live allocations may overlap
+ *   - a live allocation's bytes must never change unless we touch it
+ *
+ * Build 32-bit to match the device's pointer/struct sizes (mhdr=8, free_node=8):
+ *   gcc -m32 -O2 -g -o /tmp/mor malloc_overlap_repro.c && /tmp/mor
+ */
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+
+/* pull in the allocator under test, renamed to avoid host-libc clash */
+#define fprintf(...) (0)
+#define malloc  sut_malloc
+#define free    sut_free
+#define calloc  sut_calloc
+#define realloc sut_realloc
+#include "../malloc.c"
+#undef fprintf
+#undef malloc
+#undef free
+#undef calloc
+#undef realloc
+
+/* ---- tracking of live allocations ---- */
+#define MAXLIVE 4096
+struct live {
+  unsigned char *p;
+  size_t n;
+  unsigned char tag; /* fill byte that identifies this allocation */
+};
+static struct live live[MAXLIVE];
+static int nlive;
+static unsigned char next_tag = 1;
+
+static unsigned long long ops;
+static int violations;
+
+static void fail(const char *what, int i, int j) {
+  violations++;
+  printf("  !! VIOLATION (%s) at op %llu: live[%d]=%p+%zu",
+         what, ops, i, (void *)live[i].p, live[i].n);
+  if (j >= 0)
+    printf(" vs live[%d]=%p+%zu", j, (void *)live[j].p, live[j].n);
+  printf("\n");
+}
+
+/* full audit: pairwise overlap + content integrity */
+static void audit(void) {
+  for (int i = 0; i < nlive; i++) {
+    /* content integrity: every byte must still equal the tag */
+    for (size_t k = 0; k < live[i].n; k++) {
+      if (live[i].p[k] != live[i].tag) {
+        fail("content-clobbered", i, -1);
+        printf("     byte %zu = %02x, expected tag %02x\n",
+               k, live[i].p[k], live[i].tag);
+        break;
+      }
+    }
+    /* pairwise overlap */
+    for (int j = i + 1; j < nlive; j++) {
+      unsigned char *a0 = live[i].p, *a1 = a0 + live[i].n;
+      unsigned char *b0 = live[j].p, *b1 = b0 + live[j].n;
+      if (a0 < b1 && b0 < a1)
+        fail("overlap", i, j);
+    }
+  }
+}
+
+static void do_alloc(size_t n) {
+  if (nlive >= MAXLIVE || n == 0)
+    return;
+  unsigned char *p = sut_malloc(n);
+  if (!p)
+    return;
+  unsigned char tag = next_tag++;
+  if (next_tag == 0)
+    next_tag = 1;
+  memset(p, tag, n);
+  live[nlive].p = p;
+  live[nlive].n = n;
+  live[nlive].tag = tag;
+  nlive++;
+  ops++;
+  audit();
+}
+
+static void do_free(int idx) {
+  if (idx < 0 || idx >= nlive)
+    return;
+  sut_free(live[idx].p);
+  live[idx] = live[--nlive];
+  ops++;
+  audit();
+}
+
+static void do_realloc(int idx, size_t n) {
+  if (idx < 0 || idx >= nlive || n == 0)
+    return;
+  unsigned char tag = live[idx].tag;
+  size_t old = live[idx].n;
+  unsigned char *q = sut_realloc(live[idx].p, n);
+  if (!q)
+    return;
+  /* preserved prefix must survive */
+  size_t chk = old < n ? old : n;
+  for (size_t k = 0; k < chk; k++) {
+    if (q[k] != tag) {
+      violations++;
+      printf("  !! VIOLATION (realloc-lost-data) at op %llu: byte %zu=%02x "
+             "expected %02x\n", ops, k, q[k], tag);
+      break;
+    }
+  }
+  memset(q, tag, n); /* refill whole (grown region included) */
+  live[idx].p = q;
+  live[idx].n = n;
+  ops++;
+  audit();
+}
+
+/* deterministic PRNG (no host rand dependency) */
+static unsigned long rng_state = 0x12345678;
+static unsigned rng(void) {
+  rng_state = rng_state * 1103515245 + 12345;
+  return (rng_state >> 16) & 0x7fff;
+}
+
+int main(void) {
+  setvbuf(stdout, NULL, _IONBF, 0);
+  printf("malloc overlap reproducer  (sizeof void*=%zu mhdr=%zu free_node=%zu "
+         "MSETMAX=%d MSETLEN=%d)\n",
+         sizeof(void *), sizeof(struct mhdr), sizeof(struct free_node),
+         MSETMAX, MSETLEN);
+
+  /* --- Phase 1: random mixed stress, several seeds --- */
+  for (int seed = 1; seed <= 8; seed++) {
+    rng_state = 0x1000 * seed + 1;
+    for (int it = 0; it < 8000 && violations < 20; it++) {
+      unsigned r = rng() % 100;
+      if (r < 45) {
+        /* bias toward small (IR operands/intervals), some large */
+        size_t n = (rng() % 100 < 90) ? 8 + rng() % 400 : 4097 + rng() % 16000;
+        do_alloc(n);
+      } else if (r < 70 && nlive) {
+        do_realloc(rng() % nlive, 8 + rng() % 2000);
+      } else if (nlive) {
+        do_free(rng() % nlive);
+      }
+    }
+    /* drain */
+    while (nlive)
+      do_free(nlive - 1);
+  }
+
+  /* --- Phase 2: tcc-like growth pattern --- */
+  /* Mimic: a few arrays that grow via realloc (symtab section, interval
+     arrays) while a steady churn of small allocations (IR operands, strings)
+     happens around them. */
+  {
+    rng_state = 0xC0FFEE;
+    int growers[6];
+    for (int g = 0; g < 6; g++) {
+      do_alloc(64);
+      growers[g] = nlive - 1;
+    }
+    for (int round = 0; round < 8000 && violations < 20; round++) {
+      /* churn small allocations */
+      int burst = 1 + rng() % 6;
+      for (int b = 0; b < burst; b++)
+        do_alloc(8 + rng() % 200);
+      /* free some random small ones (not the growers) */
+      if (nlive > 12 && (rng() & 1)) {
+        int idx = 6 + rng() % (nlive - 6);
+        do_free(idx);
+        /* growers[] indices may have shifted due to swap-remove; recompute */
+        for (int g = 0; g < 6; g++) {
+          /* find grower by walking — they are the long-lived large-tagged
+             ones; simplest: re-pin by scanning is overkill, just grow the
+             first 6 live slots which remain the growers in practice */
+        }
+      }
+      /* grow a grower */
+      if (rng() % 3 == 0) {
+        int g = rng() % 6;
+        if (g < nlive)
+          do_realloc(g, 64 + (round / 100) * 8 + rng() % 128);
+      }
+    }
+    while (nlive)
+      do_free(nlive - 1);
+  }
+
+  printf("\nTotal ops: %llu   Violations: %d\n", ops, violations);
+  if (violations) {
+    printf("REPRODUCED heap corruption on host.\n");
+    return 1;
+  }
+  printf("No overlap/corruption detected with this pattern.\n");
+  return 0;
+}

--- a/tests/malloc_tests.c
+++ b/tests/malloc_tests.c
@@ -46,6 +46,12 @@
 #undef realloc
 
 static void reset_allocator_state(void) {
+  struct mset *op;
+  while (old_pools) {
+    op = old_pools;
+    old_pools = op->next_pool;
+    munmap(op, MSETLEN);
+  }
   if (pool1 != NULL) {
     munmap(pool1, MSETLEN);
     pool1 = NULL;
@@ -54,6 +60,18 @@ static void reset_allocator_state(void) {
     munmap(pool, MSETLEN);
     pool = NULL;
   }
+  memset(large_table, 0, sizeof(large_table));
+  prof_current = 0;
+  prof_peak = 0;
+  prof_total_mapped = 0;
+  prof_malloc_calls = 0;
+  prof_free_calls = 0;
+  prof_realloc_calls = 0;
+  prof_mmap_calls = 0;
+  prof_munmap_calls = 0;
+  prof_inplace = 0;
+  prof_pool_allocs = 0;
+  prof_large_allocs = 0;
 }
 
 /* ---- msize correctness ---- */
@@ -185,4 +203,241 @@ UTEST(malloc_tests, small_alloc_never_returns_page_aligned_pointer) {
   test_free(p);
   test_free(filler);
   reset_allocator_state();
+}
+
+/* ---- free list coalescing ---- */
+
+UTEST(malloc_tests, freelist_coalesces_adjacent_blocks) {
+  /* Bug: without coalescing, freeing many small adjacent blocks produced a
+     free list full of tiny entries (16-24 bytes) that could never satisfy
+     larger allocations (88-144 bytes), causing pool-full → new mmap. */
+  reset_allocator_state();
+
+  /* Allocate many small blocks consecutively */
+  #define NBLOCKS 40
+  void *ptrs[NBLOCKS];
+  for (int i = 0; i < NBLOCKS; i++) {
+    ptrs[i] = test_malloc(16); /* alloc_size = 24 each */
+    ASSERT_TRUE(ptrs[i] != NULL);
+  }
+  /* Pin some blocks so pool doesn't reach refs=0 */
+  void *pin = test_malloc(32);
+  ASSERT_TRUE(pin != NULL);
+
+  /* Free all the small blocks — they should coalesce */
+  for (int i = 0; i < NBLOCKS; i++)
+    test_free(ptrs[i]);
+
+  /* The coalesced free space should serve a larger allocation
+     without needing the bump pointer */
+  int initial_mmap_calls = prof_mmap_calls;
+  void *big = test_malloc(256);
+  ASSERT_TRUE(big != NULL);
+  /* No new mmap should have occurred — served from free list */
+  ASSERT_EQ(prof_mmap_calls, initial_mmap_calls);
+
+  memset(big, 0xCC, 256);
+
+  test_free(big);
+  test_free(pin);
+  reset_allocator_state();
+  #undef NBLOCKS
+}
+
+UTEST(malloc_tests, freelist_coalesces_with_both_neighbors) {
+  /* Free B, then A, then C where A-B-C are adjacent — should form one block */
+  reset_allocator_state();
+
+  void *a = test_malloc(32);
+  void *b = test_malloc(32);
+  void *c = test_malloc(32);
+  void *pin = test_malloc(16);
+  ASSERT_TRUE(a && b && c && pin);
+
+  /* Free middle, then left, then right */
+  test_free(b);
+  test_free(a);
+  test_free(c);
+
+  /* Coalesced block should serve a 128-byte alloc from free list */
+  int initial_mmap_calls = prof_mmap_calls;
+  void *big = test_malloc(100);
+  ASSERT_TRUE(big != NULL);
+  ASSERT_EQ(prof_mmap_calls, initial_mmap_calls);
+
+  memset(big, 0xDD, 100);
+
+  test_free(big);
+  test_free(pin);
+  reset_allocator_state();
+}
+
+/* ---- block splitting ---- */
+
+UTEST(malloc_tests, split_does_not_create_unusable_fragments) {
+  /* Bug: splitting with threshold sizeof(struct free_node)=8 created 8-byte
+     free list entries that could never be reused (min alloc_size=16).
+     Fix: only split when remainder >= 2*sizeof(struct mhdr) = 16. */
+  reset_allocator_state();
+
+  /* Allocate and free a 128-byte block */
+  void *p = test_malloc(128);
+  ASSERT_TRUE(p != NULL);
+  void *pin = test_malloc(16);
+  ASSERT_TRUE(pin != NULL);
+  test_free(p);
+
+  /* Now allocate from the free list with a size that would leave a small
+     remainder. alloc_size for malloc(120) = 128 (120+8 aligned).
+     The freed block is 136 bytes (128+8 aligned). Remainder = 8.
+     With the fix, no split occurs — the 8 bytes stay as internal frag. */
+  void *q = test_malloc(120);
+  ASSERT_TRUE(q != NULL);
+  memset(q, 0xEE, 120);
+
+  /* Free and check: free list should have at most 1 entry (the block we just
+     freed), not 1 + a useless 8-byte fragment */
+  test_free(q);
+  ASSERT_LE(freelist_count(pool), 1);
+
+  test_free(pin);
+  reset_allocator_state();
+}
+
+UTEST(malloc_tests, split_creates_usable_remainder) {
+  /* When remainder is large enough (>=16), split should produce a usable
+     second block */
+  reset_allocator_state();
+
+  /* Allocate and free a 256-byte block */
+  void *p = test_malloc(256);
+  ASSERT_TRUE(p != NULL);
+  void *pin = test_malloc(16);
+  ASSERT_TRUE(pin != NULL);
+  test_free(p);
+
+  /* Allocate 64 bytes from the 264-byte freed block.
+     alloc_size = 72. Remainder = 264-72 = 192 >= 16, so split occurs. */
+  void *q = test_malloc(64);
+  ASSERT_TRUE(q != NULL);
+  memset(q, 0xAA, 64);
+
+  /* The remainder should be on the free list and usable */
+  ASSERT_GE(freelist_count(pool), 1);
+
+  /* Allocate from the split remainder — no new mmap */
+  int initial_mmap_calls = prof_mmap_calls;
+  void *r = test_malloc(100);
+  ASSERT_TRUE(r != NULL);
+  ASSERT_EQ(prof_mmap_calls, initial_mmap_calls);
+  memset(r, 0xBB, 100);
+
+  test_free(q);
+  test_free(r);
+  test_free(pin);
+  reset_allocator_state();
+}
+
+/* ---- old pool free list reuse ---- */
+
+UTEST(malloc_tests, old_pool_drains_via_free_not_alloc) {
+  /* Old pools must NOT be searched for new allocations — doing so adds refs
+     and prevents the pool from ever reaching refs=0 for reclaim.
+     Instead, old pools drain naturally as their live allocations are freed. */
+  reset_allocator_state();
+
+  #define FILL_SIZE 48
+  #define MAX_PTRS 700
+  void *ptrs[MAX_PTRS];
+  int count = 0;
+
+  /* Fill pool to the brim until a second pool is created */
+  while (count < MAX_PTRS) {
+    void *p = test_malloc(FILL_SIZE);
+    if (!p)
+      break;
+    ptrs[count++] = p;
+    if (prof_mmap_calls >= 2)
+      break;
+  }
+  ASSERT_GE(prof_mmap_calls, 2);
+  ASSERT_TRUE(old_pools != NULL);
+
+  struct mset *old = old_pools;
+  int refs_after_fill = old->refs;
+
+  /* Free half the blocks from the old pool — refs should decrease */
+  for (int i = 0; i < count / 2 && i < 50; i++) {
+    test_free(ptrs[i]);
+    ptrs[i] = NULL;
+  }
+  ASSERT_LT(old->refs, refs_after_fill);
+
+  /* New allocations should NOT come from old pool — they use current pool */
+  int old_refs_before = old->refs;
+  void *new_alloc = test_malloc(FILL_SIZE);
+  ASSERT_TRUE(new_alloc != NULL);
+  ASSERT_EQ(old->refs, old_refs_before); /* old pool refs unchanged */
+  test_free(new_alloc);
+
+  /* Clean up */
+  for (int i = 0; i < count; i++)
+    if (ptrs[i])
+      test_free(ptrs[i]);
+  reset_allocator_state();
+  #undef FILL_SIZE
+  #undef MAX_PTRS
+}
+
+UTEST(malloc_tests, old_pool_removed_from_list_when_refs_zero) {
+  /* When all allocations from an old pool are freed, it should be removed
+     from old_pools and recycled (to pool1 or munmap'd). */
+  reset_allocator_state();
+
+  /* Create allocations that fill the first pool */
+  #define FILL_SIZE2 48
+  #define MAX_PTRS2 700
+  void *ptrs[MAX_PTRS2];
+  int count = 0;
+  while (count < MAX_PTRS2) {
+    ptrs[count] = test_malloc(FILL_SIZE2);
+    if (!ptrs[count])
+      break;
+    count++;
+    if (prof_mmap_calls >= 2)
+      break;
+  }
+  ASSERT_GE(prof_mmap_calls, 2);
+  ASSERT_TRUE(old_pools != NULL);
+
+  struct mset *old = old_pools;
+
+  /* Free ALL allocations that belong to the old pool.
+     We can identify them by the pool pointer: old pool was the first mmap,
+     current pool is the second. Pointers within old pool satisfy:
+     ptr >= (char*)old && ptr < (char*)old + MSETLEN */
+  for (int i = 0; i < count; i++) {
+    if (ptrs[i] &&
+        (char *)ptrs[i] >= (char *)old &&
+        (char *)ptrs[i] < (char *)old + MSETLEN) {
+      test_free(ptrs[i]);
+      ptrs[i] = NULL;
+    }
+  }
+
+  /* old pool should have been removed from old_pools (refs hit 0) */
+  struct mset *op;
+  int found = 0;
+  for (op = old_pools; op; op = op->next_pool)
+    if (op == old)
+      found = 1;
+  ASSERT_EQ(found, 0);
+
+  /* Clean up remaining */
+  for (int i = 0; i < count; i++)
+    if (ptrs[i])
+      test_free(ptrs[i]);
+  reset_allocator_state();
+  #undef FILL_SIZE2
+  #undef MAX_PTRS2
 }

--- a/tests/malloc_tests.c
+++ b/tests/malloc_tests.c
@@ -33,45 +33,74 @@
  * Headers above already satisfied the include-guards, so the
  * #includes inside malloc.c are harmless no-ops.
  */
+/*
+ * mmap/munmap counting shims.
+ *
+ * The production allocator carries no profiling counters (they were removed
+ * to keep per-process .bss at zero on the embedded target). Several tests
+ * still need the "no new mmap happened" signal — i.e. that a request was
+ * served from the pool free list rather than by mapping a fresh pool. We get
+ * that without touching malloc.c by counting the real mmap/munmap calls it
+ * makes. The wrappers are defined *before* the macros so their own bodies
+ * still reach the genuine libc mmap/munmap.
+ */
+static int prof_mmap_calls;
+static int prof_munmap_calls;
+static void *counting_mmap(void *addr, size_t len, int prot, int flags, int fd,
+                           off_t off) {
+  prof_mmap_calls++;
+  return mmap(addr, len, prot, flags, fd, off);
+}
+static int counting_munmap(void *addr, size_t len) {
+  prof_munmap_calls++;
+  return munmap(addr, len);
+}
+
 #define fprintf(...) (0)
 #define malloc test_malloc
 #define free test_free
 #define calloc test_calloc
 #define realloc test_realloc
+#define mmap(a, l, p, f, fd, o) counting_mmap((a), (l), (p), (f), (fd), (o))
+#define munmap(a, l) counting_munmap((a), (l))
 #include "../malloc.c"
 #undef fprintf
 #undef malloc
 #undef free
 #undef calloc
 #undef realloc
+#undef mmap
+#undef munmap
+
+/* Count entries in a pool's free list. The allocator no longer exposes a
+   helper for this, so walk the singly-linked list of free_node directly. */
+static int freelist_count(struct mset *m) {
+  int count = 0;
+  if (!m)
+    return 0;
+  for (struct free_node *fn = (struct free_node *)m->freelist; fn;
+       fn = fn->next)
+    count++;
+  return count;
+}
 
 static void reset_allocator_state(void) {
   struct mset *op;
   while (old_pools) {
     op = old_pools;
     old_pools = op->next_pool;
-    munmap(op, MSETLEN);
+    counting_munmap(op, MSETLEN);
   }
   if (pool1 != NULL) {
-    munmap(pool1, MSETLEN);
+    counting_munmap(pool1, MSETLEN);
     pool1 = NULL;
   }
   if (pool != NULL) {
-    munmap(pool, MSETLEN);
+    counting_munmap(pool, MSETLEN);
     pool = NULL;
   }
-  memset(large_table, 0, sizeof(large_table));
-  prof_current = 0;
-  prof_peak = 0;
-  prof_total_mapped = 0;
-  prof_malloc_calls = 0;
-  prof_free_calls = 0;
-  prof_realloc_calls = 0;
   prof_mmap_calls = 0;
   prof_munmap_calls = 0;
-  prof_inplace = 0;
-  prof_pool_allocs = 0;
-  prof_large_allocs = 0;
 }
 
 /* ---- msize correctness ---- */

--- a/tests/math_runtime_tests.c
+++ b/tests/math_runtime_tests.c
@@ -1,0 +1,115 @@
+// Copyright (c) 2025 Mateusz Stadnik <matgla@live.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <limits.h>
+
+#include "../../libm/include/math.h"
+#include "utest.h"
+
+typedef union {
+  double _Complex value;
+  struct {
+    double real;
+    double imag;
+  } parts;
+} double_complex_parts;
+
+typedef union {
+  double value;
+  unsigned long long bits;
+} double_bits;
+
+typedef union {
+  float value;
+  unsigned int bits;
+} float_bits;
+
+long double sut_fmaxl(long double left, long double right);
+int sut_ilogb(double value);
+int sut_ilogbf(float value);
+int sut_ilogbl(long double value);
+double _Complex sut___divdc3(double a_real, double a_imag, double b_real,
+                             double b_imag);
+
+static double fabs_test(double value) {
+  return value < 0.0 ? -value : value;
+}
+
+static double make_double(unsigned long long bits) {
+  double_bits repr;
+
+  repr.bits = bits;
+  return repr.value;
+}
+
+static float make_float(unsigned int bits) {
+  float_bits repr;
+
+  repr.bits = bits;
+  return repr.value;
+}
+
+UTEST(math_runtime_tests, fmaxl_picks_larger_value) {
+  ASSERT_EQ(4.0L, sut_fmaxl(4.0L, 3.0L));
+  ASSERT_EQ(7.5L, sut_fmaxl(-1.0L, 7.5L));
+  ASSERT_EQ(0.0L, sut_fmaxl(-0.0L, 0.0L));
+}
+
+UTEST(math_runtime_tests, ilogbl_returns_unbiased_exponent) {
+  ASSERT_EQ(0, sut_ilogbl(1.0L));
+  ASSERT_EQ(5, sut_ilogbl(32.0L));
+  ASSERT_EQ(-3, sut_ilogbl(0.125L));
+  ASSERT_EQ(FP_ILOGB0, sut_ilogbl(0.0L));
+}
+
+UTEST(math_runtime_tests, ilogb_and_ilogbf_follow_ilogbl_for_finite_values) {
+  ASSERT_EQ(3, sut_ilogb(8.0));
+  ASSERT_EQ(-4, sut_ilogb(0.0625));
+  ASSERT_EQ(4, sut_ilogbf(16.0f));
+  ASSERT_EQ(-2, sut_ilogbf(0.25f));
+}
+
+UTEST(math_runtime_tests, ilogb_family_handles_zero_nan_and_infinity) {
+  const double infinity = make_double(0x7ff0000000000000ULL);
+  const double nan = make_double(0x7ff8000000000000ULL);
+  const float infinityf = make_float(0x7f800000U);
+  const float nanf = make_float(0x7fc00000U);
+
+  ASSERT_EQ(FP_ILOGB0, sut_ilogb(0.0));
+  ASSERT_EQ(FP_ILOGB0, sut_ilogbf(0.0f));
+  ASSERT_EQ(FP_ILOGB0, sut_ilogbl(0.0L));
+
+  ASSERT_EQ(INT_MAX, sut_ilogb(infinity));
+  ASSERT_EQ(INT_MAX, sut_ilogbf(infinityf));
+  ASSERT_EQ(INT_MAX, sut_ilogbl((long double)infinity));
+
+  ASSERT_EQ(FP_ILOGBNAN, sut_ilogb(nan));
+  ASSERT_EQ(FP_ILOGBNAN, sut_ilogbf(nanf));
+  ASSERT_EQ(FP_ILOGBNAN, sut_ilogbl((long double)nan));
+}
+
+UTEST(math_runtime_tests, divdc3_divides_complex_doubles) {
+  double_complex_parts result;
+
+  result.value = sut___divdc3(1.0, 2.0, 3.0, 4.0);
+
+  ASSERT_LT(fabs_test(result.parts.real - 0.44), 1e-12);
+  ASSERT_LT(fabs_test(result.parts.imag - 0.08), 1e-12);
+}

--- a/tests/rename_symbols.sh
+++ b/tests/rename_symbols.sh
@@ -3,7 +3,7 @@
 nm $1 | awk '{print $3}' | while read -r symbol; do
     [ -z "$symbol" ] && continue
     case "$symbol" in
-        sut_*) continue ;;
+        sut_*|__call_with_got) continue ;;
     esac
     objcopy --redefine-sym="$symbol"="sut_$symbol" "$1"
 done

--- a/tests/stdio_tests.c
+++ b/tests/stdio_tests.c
@@ -1,0 +1,95 @@
+/*
+ Copyright (c) 2025 Mateusz Stadnik <matgla@live.com>
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+*/
+
+#include "utest.h"
+
+#include <string.h>
+#include <sys/syscall.h>
+
+#include "syscalls_stub.h"
+
+int sut_puts(const char *s);
+int sut_fputs(const char *s, void *fp);
+int sut_fflush(void *fp);
+extern void *sut_stdout;
+
+/* Buffer to capture write() output */
+static char capture_buf[256];
+static int capture_len;
+
+static void capture_write(int number, const void *args,
+                          syscall_result *result) {
+  (void)number;
+  const write_context *ctx = (const write_context *)args;
+  int to_copy = (int)ctx->count;
+  if (capture_len + to_copy > (int)sizeof(capture_buf))
+    to_copy = (int)sizeof(capture_buf) - capture_len;
+  memcpy(capture_buf + capture_len, ctx->buf, to_copy);
+  capture_len += to_copy;
+  *ctx->result = to_copy;
+  result->result = 0;
+  result->err = -1;
+}
+
+static void reset_capture(void) {
+  capture_len = 0;
+  memset(capture_buf, 0, sizeof(capture_buf));
+  RESET_FAKE(trigger_supervisor_call);
+  trigger_supervisor_call_fake.custom_fake = capture_write;
+}
+
+UTEST(stdio_tests, puts_returns_char_count) {
+  reset_capture();
+  int ret = sut_puts("hello");
+  /* "hello" + '\n' = 6 */
+  ASSERT_EQ(ret, 6);
+  ASSERT_EQ(capture_len, 6);
+  ASSERT_EQ(0, memcmp(capture_buf, "hello\n", 6));
+
+  reset_capture();
+  ret = sut_puts("");
+  /* "" + '\n' = 1 */
+  ASSERT_EQ(ret, 1);
+  ASSERT_EQ(capture_len, 1);
+  ASSERT_EQ(capture_buf[0], '\n');
+
+  reset_capture();
+  ret = sut_puts("abc");
+  ASSERT_EQ(ret, 4);
+  ASSERT_EQ(capture_len, 4);
+  ASSERT_EQ(0, memcmp(capture_buf, "abc\n", 4));
+}
+
+UTEST(stdio_tests, fputs_returns_char_count) {
+  reset_capture();
+  int ret = sut_fputs("hello", sut_stdout);
+  ASSERT_EQ(ret, 5);
+  sut_fflush(sut_stdout);
+  ASSERT_EQ(capture_len, 5);
+  ASSERT_EQ(0, memcmp(capture_buf, "hello", 5));
+}
+
+UTEST(stdio_tests, fputs_returns_eof_on_null_file) {
+  int ret = sut_fputs("hello", NULL);
+  ASSERT_EQ(ret, -1);
+}

--- a/tests/stdio_tests.c
+++ b/tests/stdio_tests.c
@@ -23,6 +23,8 @@
 
 #include "utest.h"
 
+#include <fcntl.h>
+#include <stdio.h>
 #include <string.h>
 #include <sys/syscall.h>
 
@@ -31,11 +33,20 @@
 int sut_puts(const char *s);
 int sut_fputs(const char *s, void *fp);
 int sut_fflush(void *fp);
+char *sut_tmpnam(char *buffer);
+void *sut_freopen(const char *path, const char *mode, void *fp);
+int sut_fileno(void *fp);
 extern void *sut_stdout;
 
 /* Buffer to capture write() output */
 static char capture_buf[256];
 static int capture_len;
+static int syscall_sequence[8];
+static int syscall_sequence_len;
+static int freopen_closed_fd;
+static int freopen_open_fd;
+static int freopen_open_flags;
+static char freopen_open_path[64];
 
 static void capture_write(int number, const void *args,
                           syscall_result *result) {
@@ -54,8 +65,58 @@ static void capture_write(int number, const void *args,
 static void reset_capture(void) {
   capture_len = 0;
   memset(capture_buf, 0, sizeof(capture_buf));
+  syscall_sequence_len = 0;
+  freopen_closed_fd = -1;
+  freopen_open_fd = -1;
+  freopen_open_flags = 0;
+  memset(freopen_open_path, 0, sizeof(freopen_open_path));
   RESET_FAKE(trigger_supervisor_call);
   trigger_supervisor_call_fake.custom_fake = capture_write;
+}
+
+static void record_syscall(int number) {
+  if (syscall_sequence_len < (int)(sizeof(syscall_sequence) /
+                                   sizeof(syscall_sequence[0]))) {
+    syscall_sequence[syscall_sequence_len++] = number;
+  }
+}
+
+static void freopen_syscalls(int number, const void *args,
+                             syscall_result *result) {
+  record_syscall(number);
+
+  switch (number) {
+  case sys_write: {
+    const write_context *ctx = (const write_context *)args;
+    int to_copy = (int)ctx->count;
+    if (capture_len + to_copy > (int)sizeof(capture_buf))
+      to_copy = (int)sizeof(capture_buf) - capture_len;
+    memcpy(capture_buf + capture_len, ctx->buf, to_copy);
+    capture_len += to_copy;
+    *ctx->result = to_copy;
+    result->result = 0;
+    result->err = -1;
+    return;
+  }
+  case sys_close:
+    freopen_closed_fd = *(const int *)args;
+    result->result = 0;
+    result->err = -1;
+    return;
+  case sys_open: {
+    const open_context *ctx = (const open_context *)args;
+    freopen_open_fd = 11;
+    freopen_open_flags = ctx->flags;
+    strncpy(freopen_open_path, ctx->path, sizeof(freopen_open_path) - 1);
+    result->result = freopen_open_fd;
+    result->err = -1;
+    return;
+  }
+  default:
+    result->result = 0;
+    result->err = -1;
+    return;
+  }
 }
 
 UTEST(stdio_tests, puts_returns_char_count) {
@@ -92,4 +153,42 @@ UTEST(stdio_tests, fputs_returns_char_count) {
 UTEST(stdio_tests, fputs_returns_eof_on_null_file) {
   int ret = sut_fputs("hello", NULL);
   ASSERT_EQ(ret, -1);
+}
+
+UTEST(stdio_tests, tmpnam_generates_unique_paths) {
+  char first[L_tmpnam];
+  char second[L_tmpnam];
+  char *internal;
+
+  ASSERT_EQ(first, sut_tmpnam(first));
+  ASSERT_EQ(second, sut_tmpnam(second));
+  ASSERT_NE(NULL, sut_tmpnam(NULL));
+
+  internal = sut_tmpnam(NULL);
+  ASSERT_NE(NULL, internal);
+  ASSERT_STREQ(first, first);
+  ASSERT_STREQ(second, second);
+  ASSERT_NE(0, strcmp(first, second));
+  ASSERT_EQ(0, memcmp(first, P_tmpdir "/tmp_", 9));
+  ASSERT_EQ(0, memcmp(second, P_tmpdir "/tmp_", 9));
+  ASSERT_EQ(0, memcmp(internal, P_tmpdir "/tmp_", 9));
+}
+
+UTEST(stdio_tests, freopen_flushes_closes_and_reopens_stream) {
+  reset_capture();
+  trigger_supervisor_call_fake.custom_fake = freopen_syscalls;
+
+  ASSERT_EQ(3, sut_fputs("abc", sut_stdout));
+  ASSERT_EQ(sut_stdout, sut_freopen("/tmp/reopened.log", "w", sut_stdout));
+
+  ASSERT_EQ(3, capture_len);
+  ASSERT_EQ(0, memcmp(capture_buf, "abc", 3));
+  ASSERT_EQ(3, syscall_sequence_len);
+  ASSERT_EQ(sys_write, syscall_sequence[0]);
+  ASSERT_EQ(sys_close, syscall_sequence[1]);
+  ASSERT_EQ(sys_open, syscall_sequence[2]);
+  ASSERT_EQ(STDOUT_FILENO, freopen_closed_fd);
+  ASSERT_STREQ("/tmp/reopened.log", freopen_open_path);
+  ASSERT_EQ(O_WRONLY | O_CREAT | O_TRUNC, freopen_open_flags);
+  ASSERT_EQ(freopen_open_fd, sut_fileno(sut_stdout));
 }

--- a/tests/stdio_tests.c
+++ b/tests/stdio_tests.c
@@ -26,6 +26,7 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/mman.h>
 #include <sys/syscall.h>
 
 #include "syscalls_stub.h"
@@ -83,6 +84,27 @@ static void record_syscall(int number) {
 
 static void freopen_syscalls(int number, const void *args,
                              syscall_result *result) {
+  /* freopen() reopens a stream and (re)allocates its buffers, so the libc
+     allocator's internal mmap/munmap may fire here. Service them with the real
+     host mmap so malloc() returns usable, page-aligned memory — but do NOT
+     record them: the test asserts only the observable I/O sequence
+     (write, close, open). */
+  if (number == sys_mmap) {
+    const mmap_context *ctx = (const mmap_context *)args;
+    *ctx->result = mmap(NULL, (size_t)ctx->length, PROT_READ | PROT_WRITE,
+                        MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    result->result = 0;
+    result->err = -1;
+    return;
+  }
+  if (number == sys_munmap) {
+    const munmap_context *ctx = (const munmap_context *)args;
+    munmap(ctx->addr, (size_t)ctx->length);
+    result->result = 0;
+    result->err = -1;
+    return;
+  }
+
   record_syscall(number);
 
   switch (number) {
@@ -155,10 +177,25 @@ UTEST(stdio_tests, fputs_returns_eof_on_null_file) {
   ASSERT_EQ(ret, -1);
 }
 
+/* tmpnam probes each candidate with access(F_OK) and keeps the first one that
+   does NOT already exist. Report "not found" (rc != 0) for every probe so the
+   first candidate is accepted; without this the stub leaves access() returning
+   0 ("exists") and tmpnam exhausts TMP_MAX and returns NULL. */
+static void tmpnam_access_not_found(int number, const void *args,
+                                    syscall_result *result) {
+  (void)number;
+  (void)args;
+  result->result = -1;
+  result->err = -1;
+}
+
 UTEST(stdio_tests, tmpnam_generates_unique_paths) {
   char first[L_tmpnam];
   char second[L_tmpnam];
   char *internal;
+
+  RESET_FAKE(trigger_supervisor_call);
+  trigger_supervisor_call_fake.custom_fake = tmpnam_access_not_found;
 
   ASSERT_EQ(first, sut_tmpnam(first));
   ASSERT_EQ(second, sut_tmpnam(second));

--- a/tests/string_tests.c
+++ b/tests/string_tests.c
@@ -20,10 +20,31 @@
 
 #include "utest.h"
 
+void *sut_memchr(const void *s, int c, long n);
+void *sut_mempcpy(void *dst, const void *src, size_t n);
 char *sut_strchr(char *s, int c);
 size_t sut_strspn(const char *s, const char *accept);
 size_t sut_strcspn(const char *s, const char *reject);
 char *sut_strtok(char *s, const char *delimiters);
+
+UTEST(string_tests, memchr) {
+  const unsigned char bytes[] = {'A', 'B', 0, 'C', 'B'};
+
+  ASSERT_EQ(bytes + 1, sut_memchr(bytes, 'B', sizeof(bytes)));
+  ASSERT_EQ(bytes + 2, sut_memchr(bytes, 0, sizeof(bytes)));
+  ASSERT_EQ(NULL, sut_memchr(bytes, 'B', 1));
+  ASSERT_EQ(NULL, sut_memchr(bytes, 'Z', sizeof(bytes)));
+  ASSERT_EQ(NULL, sut_memchr(bytes, 'A', 0));
+}
+
+UTEST(string_tests, mempcpy) {
+  unsigned char dst[8] = {0};
+  const unsigned char src[] = {'a', 'b', 'c', 'd'};
+
+  ASSERT_EQ(dst + sizeof(src), sut_mempcpy(dst, src, sizeof(src)));
+  ASSERT_EQ(0, memcmp(dst, src, sizeof(src)));
+  ASSERT_EQ(dst, sut_mempcpy(dst, src, 0));
+}
 
 UTEST(string_tests, strchr) {
   char *str = "Wait is this a Hello, World?";

--- a/tests/symbols_redefines.txt
+++ b/tests/symbols_redefines.txt
@@ -15,6 +15,7 @@ sem_trywait sut_sem_trywait
 sem_unlink sut_sem_unlink
 sem_wait sut_sem_wait
 puts sut_puts
+fputs sut_fputs
 scanf sut_scanf
 printf sut_printf
 write sut_write

--- a/tests/symbols_redefines.txt
+++ b/tests/symbols_redefines.txt
@@ -21,6 +21,7 @@ printf sut_printf
 write sut_write
 strlen sut_strlen
 isatty sut_isatty
+memchr sut_memchr
 memset sut_memset
 isspace sut_isspace
 prlimit sut_prlimit

--- a/tests/syscalls_stub.c
+++ b/tests/syscalls_stub.c
@@ -24,3 +24,9 @@ DEFINE_FFF_GLOBALS
 
 DEFINE_FAKE_VOID_FUNC(trigger_supervisor_call, int, const void *,
                       syscall_result *);
+
+/* Host stub for ARM-only __call_with_got (calls func, ignores got_base) */
+void __call_with_got(void (*func)(void), void *got_base) {
+  (void)got_base;
+  func();
+}

--- a/time.c
+++ b/time.c
@@ -20,11 +20,17 @@
 
 #include <time.h>
 
+#include <sys/time.h>
+
 #include <stdio.h>
 
 int clock_gettime(clockid_t clockid, struct timespec *res) {
-  time_t now = time(NULL); 
-  res->tv_sec = now;
-  res->tv_nsec = 0;
+  struct timeval tv;
+  (void)clockid;
+  if (gettimeofday(&tv, NULL) != 0) {
+    return -1;
+  }
+  res->tv_sec = tv.tv_sec;
+  res->tv_nsec = tv.tv_usec * 1000;
   return 0;
 }

--- a/tmpnam.c
+++ b/tmpnam.c
@@ -18,14 +18,47 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#pragma once
+#include <stdio.h>
+#include <unistd.h>
 
-#include <locale.h>
-#include <stddef.h>
+static unsigned int tmpnam_counter;
 
-int ffs(int value);
-int ffsl(long value);
-int ffsll(long long value);
-int strncasecmp(const char *s1, const char *s2, size_t n);
-int strncasecmp_l(const char *s1, const char *s2, size_t n, locale_t locale);
-int strcasecmp(const char *s1, const char *s2);
+static void append_hex(char *out, unsigned int value) {
+  static const char hex_digits[] = "0123456789abcdef";
+  int index;
+
+  for (index = 0; index < 8; ++index) {
+    out[7 - index] = hex_digits[value & 0x0f];
+    value >>= 4;
+  }
+}
+
+char *tmpnam(char *buffer) {
+  static char internal_buffer[L_tmpnam];
+  char *result = buffer != NULL ? buffer : internal_buffer;
+  unsigned int sequence = tmpnam_counter;
+  int attempt;
+
+  for (attempt = 0; attempt < TMP_MAX; ++attempt) {
+    unsigned int token = (unsigned int)getpid() ^ (sequence + (unsigned int)attempt);
+
+    result[0] = '/';
+    result[1] = 't';
+    result[2] = 'm';
+    result[3] = 'p';
+    result[4] = '/';
+    result[5] = 't';
+    result[6] = 'm';
+    result[7] = 'p';
+    result[8] = '_';
+    append_hex(result + 9, token);
+    result[17] = '\0';
+
+    if (access(result, F_OK) != 0) {
+      tmpnam_counter = sequence + (unsigned int)attempt + 1;
+      return result;
+    }
+  }
+
+  return NULL;
+}

--- a/unistd.c
+++ b/unistd.c
@@ -271,13 +271,11 @@ int symlinkat(const char *target, int newdirfd, const char *linkpath) {
 }
 
 int ftruncate(int fd, off_t length) {
-  printf("TODO: Implement ftruncate\n");
-  return -1;
-  // truncate_context context = {
-  //     .fd = fd,
-  //     .length = length,
-  // };
-  // return trigger_syscall(sys_ftruncate, &context);
+  ftruncate_context context = {
+      .fd = fd,
+      .length = length,
+  };
+  return trigger_syscall(sys_ftruncate, &context);
 }
 
 char login_[8] = {'r', 'o', 'o', 't', '\0'};

--- a/unistd.c
+++ b/unistd.c
@@ -5,6 +5,7 @@
 
 #include <unistd.h>
 
+#include <fcntl.h> /* AT_FDCWD */
 #include <signal.h>
 #include <stdarg.h>
 #include <stdlib.h>


### PR DESCRIPTION
New runtime + headers (NF):
- bitops.c: clz/ctz/popcount/parity compiler-rt helpers
- complex.c, math_runtime.c (fmaxl, ilogb family, divdc3, ...)
- tmpnam.c, endian.h, sys/klog.{c,h}, sys/perf.{c,h}

Internal fixes (IP):
- malloc.c: self-tracking large allocs (in-mapping header, no fixed
  table), free-list coalescing + safe splitting, vfork save/restore,
  leak fixes
- stdio: buffering overhaul, freopen, fclose keeps static std streams,
  self-host/float printf fixes; scanf, stdlib, syscalls additions

Tests:
- host unit tests for bitops/complex/math/stdio/malloc
- standalone malloc overlap stress reproducers (make stress)
- fix suite to match new malloc API; make test green (72/72)